### PR TITLE
Refactor basic intelligence into its own personality construct

### DIFF
--- a/src/engine/bot-engine.spec.ts
+++ b/src/engine/bot-engine.spec.ts
@@ -1,8 +1,89 @@
 import { BotEngine } from './bot-engine';
+import { IMock, Mock, It, Times } from 'typemoq';
+import { Client } from '../interfaces/client';
+import * as LifecycleEvents from '../constants/lifecycle-events';
+
+const MOCK_TOKEN = '';
 
 describe('Bot engine', () => {
+  let client: IMock<Client>;
+
+  beforeEach(() => {
+    client = Mock.ofType<Client>();
+  });
+
   it('should construct', () => {
-    const engine = new BotEngine(null);
+    const engine = new BotEngine(client.object);
     expect(engine).toBeTruthy();
+  });
+
+  it('should connect on run', () => {
+    client.setup(m => m.connect(It.isAnyString()));
+    const engine = new BotEngine(client.object);
+
+    engine.run();
+
+    client.verify(m => m.connect(It.isValue(MOCK_TOKEN)), Times.once());
+  });
+
+  it('should initialise event listeners on run', () => {
+    client.setup(m => m.on(It.isAnyString(), It.isAny()));
+    const engine = new BotEngine(client.object);
+
+    engine.run();
+
+    // Connected and message
+    client.verify(
+      m => m.on(It.isValue(LifecycleEvents.CONNECTED), It.isAny()),
+      Times.once()
+    );
+    client.verify(
+      m => m.on(It.isValue(LifecycleEvents.MESSAGE), It.isAny()),
+      Times.once()
+    );
+  });
+
+  it('should add connection event handler on connection', () => {
+    const engine = new BotEngine(client.object);
+    const untypedEngine = engine as any;
+    spyOn(untypedEngine, 'onConnected');
+
+    const callbacks: { evt: string; cb: Function }[] = [];
+    client
+      .setup(m => m.on(It.isAnyString(), It.isAny()))
+      .callback((evt: string, cb: Function) => {
+        callbacks.push({ evt, cb });
+      });
+
+    engine.run();
+
+    const relatedHandler = callbacks.find(
+      cb => cb.evt === LifecycleEvents.CONNECTED
+    );
+    relatedHandler.cb.call(client);
+
+    expect(untypedEngine.onConnected).toHaveBeenCalled();
+  });
+
+  it('should add connection event handler on connection', () => {
+    const engine = new BotEngine(client.object);
+    const untypedEngine = engine as any;
+    spyOn(untypedEngine, 'onMessage');
+
+    const callbacks: { evt: string; cb: Function }[] = [];
+    client
+      .setup(m => m.on(It.isAnyString(), It.isAny()))
+      .callback((evt: string, cb: Function) => {
+        callbacks.push({ evt, cb });
+      });
+
+    engine.run();
+
+    const relatedHandler = callbacks.find(
+      cb => cb.evt === LifecycleEvents.MESSAGE
+    );
+    relatedHandler.cb.call(client);
+
+    expect(untypedEngine.onMessage).toHaveBeenCalled();
   });
 });

--- a/src/engine/bot-engine.spec.ts
+++ b/src/engine/bot-engine.spec.ts
@@ -3,8 +3,6 @@ import { IMock, Mock, It, Times } from 'typemoq';
 import { Client } from '../interfaces/client';
 import * as LifecycleEvents from '../constants/lifecycle-events';
 
-const MOCK_TOKEN = '';
-
 describe('Bot engine', () => {
   let client: IMock<Client>;
 
@@ -23,7 +21,7 @@ describe('Bot engine', () => {
 
     engine.run();
 
-    client.verify(m => m.connect(It.isValue(MOCK_TOKEN)), Times.once());
+    client.verify(m => m.connect(It.isAnyString()), Times.once());
   });
 
   it('should initialise event listeners on run', () => {

--- a/src/engine/bot-engine.spec.ts
+++ b/src/engine/bot-engine.spec.ts
@@ -1,0 +1,8 @@
+import { BotEngine } from './bot-engine';
+
+describe('Bot engine', () => {
+  it('should construct', () => {
+    const engine = new BotEngine(null);
+    expect(engine).toBeTruthy();
+  });
+});

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -19,16 +19,23 @@ export class BotEngine implements Engine {
   }
 
   private attachEvents(): void {
-    this.client.on(LifecycleEvents.CONNECTED, () => console.log('Connected'));
+    this.client.on(LifecycleEvents.CONNECTED, () => this.onConnected());
+    this.client.on(LifecycleEvents.MESSAGE, (message: discord.Message) =>
+      this.onMessage(message)
+    );
+  }
 
-    this.client.on(LifecycleEvents.MESSAGE, (message: discord.Message) => {
-      if (message.content === '+echo') {
-        this.client.queueMessages(['echo!'], message.channel);
-      }
+  private onConnected(): void {
+    console.log('Connected');
+  }
 
-      if (message.content === '+leave') {
-        this.client.disconnect();
-      }
-    });
+  private onMessage(message: discord.Message): void {
+    if (message.content === '+echo') {
+      this.client.queueMessages(['echo!'], message.channel);
+    }
+
+    if (message.content === '+leave') {
+      this.client.disconnect();
+    }
   }
 }

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -3,15 +3,24 @@ import { injectable, inject } from 'inversify';
 import * as discord from 'discord.js';
 
 import * as LifecycleEvents from '../constants/lifecycle-events';
-import { Client } from '../interfaces/client';
 import { TYPES } from '../constants/types';
+import { Client } from '../interfaces/client';
 import { Engine } from '../interfaces/engine';
+import { Personality } from '../interfaces/personality';
 
 const token = ''; // DO NOT SUBMIT
 
 @injectable()
 export class BotEngine implements Engine {
-  constructor(@inject(TYPES.Client) private client: Client) {}
+  private personalityConstructs: Personality[];
+
+  constructor(@inject(TYPES.Client) private client: Client) {
+    this.personalityConstructs = [];
+  }
+
+  public addPersonality(personality: Personality): void {
+    this.personalityConstructs.push(personality);
+  }
 
   public run(): void {
     this.attachEvents();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,8 @@ import { container } from './infrastructure/installer';
 import { TYPES } from './constants/types';
 import { Engine } from './interfaces/engine';
 
+import { BasicIntelligence } from './personality/basic-intelligence';
+
 const botEngine = container.get<Engine>(TYPES.Engine);
+botEngine.addPersonality(new BasicIntelligence); // TODO: dep injection
 botEngine.run();

--- a/src/interfaces/engine.ts
+++ b/src/interfaces/engine.ts
@@ -1,3 +1,6 @@
+import { Personality } from './personality';
+
 export interface Engine {
+  addPersonality(personality: Personality): void;
   run(): void;
 }

--- a/src/interfaces/personality.ts
+++ b/src/interfaces/personality.ts
@@ -1,0 +1,6 @@
+import * as discord from 'discord.js';
+
+export interface Personality {
+  onAddressed(message: discord.Message): Promise<string>;
+  onMessage(message: discord.Message): Promise<string>;
+}

--- a/src/personality/basic-intelligence.spec.ts
+++ b/src/personality/basic-intelligence.spec.ts
@@ -1,0 +1,27 @@
+import { Mock } from 'typemoq';
+import { BasicIntelligence } from './basic-intelligence';
+import { Message } from 'discord.js';
+
+describe('basic intelligence', () => {
+  it('should not handle an addressed message', (done: DoneFn) => {
+    const message = Mock.ofType<Message>();
+    message.setup(m => m.content).returns(() => 'anything');
+    const core = new BasicIntelligence();
+
+    core.onAddressed(message.object).then((result: string) => {
+      expect(result).toBe(null);
+      done();
+    });
+  });
+
+  it('should handle an ambient message with the echo command', (done: DoneFn) => {
+    const message = Mock.ofType<Message>();
+    message.setup(m => m.content).returns(() => '+echo');
+    const core = new BasicIntelligence();
+
+    core.onMessage(message.object).then((result: string) => {
+      expect(result).toBe('Echo!');
+      done();
+    });
+  });
+});

--- a/src/personality/basic-intelligence.ts
+++ b/src/personality/basic-intelligence.ts
@@ -1,0 +1,18 @@
+import * as discord from 'discord.js';
+import { Personality } from '../interfaces/personality';
+
+export class BasicIntelligence implements Personality {
+  onAddressed(message: discord.Message): Promise<string> {
+    return Promise.resolve(null);
+  }
+
+  onMessage(message: discord.Message): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (message.content === '+echo') {
+        resolve('Echo!');
+      }
+
+      resolve(null);
+    });
+  }
+}


### PR DESCRIPTION
Title obviously stolen from Portal.

This change set updates the bot engine to be able to dynamically call ‘personality constructs’ when messages are received. These constructs are simple classes which contain two methods, `onMessaged` and `onAddressed`. `onMessaged` is called whenever there is a new message in a text channel. `onAddressed` is planned to be called whenever someone addresses the bot directly, or with a specific phrase – however, it is not implemented in this change set.

It also moves the `+echo` command into its own class, which is then called with the new calling mechanism.