### PR TITLE
Implement logic to detect whether the bot has been addressed

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,6 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "ignore": ["src/**/*.spec.ts"],
+  "exec": "ts-node src/index.ts"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc",
     "test": "jasmine-ts",
     "coverage": "nyc npm test",
-    "watch": "nodemon -e tsc -w ./src -x ts-node src/index.ts",
+    "watch": "nodemon",
     "lint": "tslint --project tsconfig.json --config tslint.json",
     "lint:fix": "prettier --config ./.prettierrc --write ./src/**/*.ts",
     "pr-check": "npm run build && npm run test && npm run lint"

--- a/src/engine/bot-engine.spec.ts
+++ b/src/engine/bot-engine.spec.ts
@@ -161,6 +161,7 @@ describe('Bot engine', () => {
       { input: 'hehehe', expectedOutput: null },
       { input: 'okay', expectedOutput: null },
       { input: 'hey', expectedOutput: null },
+      { input: `hey${MOCK_USERNAME}`, expectedOutput: null }, // no space before bot name
       { input: `long ${MOCK_USERNAME}: message`, expectedOutput: null },
       { input: `${MOCK_USERNAME}, hello`, expectedOutput: 'hello' },
       { input: `${MOCK_USERNAME} hello`, expectedOutput: 'hello' },

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -7,6 +7,7 @@ import { TYPES } from '../constants/types';
 import { Client } from '../interfaces/client';
 import { Engine } from '../interfaces/engine';
 import { Personality } from '../interfaces/personality';
+import { getValueStartedWith, isPunctuation } from '../utils';
 
 const token = ''; // DO NOT SUBMIT
 
@@ -65,5 +66,56 @@ export class BotEngine implements Engine {
     const funcs = this.personalityConstructs.map((c: Personality) => c.onMessage(message));
     funcs.push(Promise.resolve(null));
     this.dequeuePromises(funcs);
+  }
+
+  private calculateAddressedMessage(message: discord.Message): string {
+    const botInfo = this.client.getUserInformation();
+    const username = botInfo.username;
+    const botId = `<@${botInfo.id}>`;
+    const messageText = message.content.replace(botId, username);
+
+    const lowercaseMessage = messageText.toLowerCase();
+    const lowercaseUsername = username.toLowerCase();
+    const usernameLocation = lowercaseMessage.indexOf(lowercaseUsername);
+
+    if (usernameLocation < 0) {
+      return null;
+    }
+
+    if (usernameLocation > 0) {
+      const attentionGrabbers = ['hey', 'ok', 'okay'];
+      const attentionGrabber = getValueStartedWith(
+        lowercaseMessage,
+        attentionGrabbers
+      );
+      if (!attentionGrabber) {
+        return null;
+      }
+
+      const characterAfterAttentionGrabber = messageText.charAt(
+        attentionGrabber.length
+      );
+      const hasAttentionGrabber =
+        characterAfterAttentionGrabber === ' ' &&
+        usernameLocation === attentionGrabber.length + 1;
+
+      if (!hasAttentionGrabber) {
+        return null;
+      }
+    }
+
+    let messageLocation = usernameLocation + username.length;
+    if (messageLocation > messageText.length) {
+      return '';
+    }
+
+    const messageStartsWithPunctuation = isPunctuation(
+      messageText.charAt(messageLocation)
+    );
+    if (messageStartsWithPunctuation) {
+      messageLocation += 1;
+    }
+
+    return messageText.substr(messageLocation).trim();
   }
 }

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -105,7 +105,7 @@ export class BotEngine implements Engine {
     }
 
     let messageLocation = usernameLocation + username.length;
-    if (messageLocation > messageText.length) {
+    if (messageLocation >= messageText.length) {
       return '';
     }
 

--- a/src/interfaces/personality.ts
+++ b/src/interfaces/personality.ts
@@ -1,6 +1,6 @@
 import * as discord from 'discord.js';
 
 export interface Personality {
-  onAddressed(message: discord.Message): Promise<string>;
+  onAddressed(message: discord.Message, addressedMessage: string): Promise<string>;
   onMessage(message: discord.Message): Promise<string>;
 }

--- a/src/personality/basic-intelligence.spec.ts
+++ b/src/personality/basic-intelligence.spec.ts
@@ -8,7 +8,7 @@ describe('basic intelligence', () => {
     message.setup(m => m.content).returns(() => 'anything');
     const core = new BasicIntelligence();
 
-    core.onAddressed(message.object).then((result: string) => {
+    core.onAddressed(message.object, 'anything').then((result: string) => {
       expect(result).toBe(null);
       done();
     });

--- a/src/personality/basic-intelligence.ts
+++ b/src/personality/basic-intelligence.ts
@@ -2,7 +2,7 @@ import * as discord from 'discord.js';
 import { Personality } from '../interfaces/personality';
 
 export class BasicIntelligence implements Personality {
-  onAddressed(message: discord.Message): Promise<string> {
+  onAddressed(message: discord.Message, addressedMessage: string): Promise<string> {
     return Promise.resolve(null);
   }
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,51 @@
+import { isPunctuation, getValueStartedWith } from './utils';
+
+describe('utilities - test whether character is in a regex', () => {
+  it('should match specific punctuation', () => {
+    const matchingPunctuation = '.,:;!?';
+
+    for (let index = 0; index < matchingPunctuation.length; index += 1) {
+      const result = isPunctuation(matchingPunctuation.charAt(index));
+      expect(result).toBe(true);
+    }
+  });
+
+  it('should not match non-punctuation', () => {
+    const randomChars = Date.now().toString().substring(2);
+
+    for (let index = 0; index < randomChars.length; index += 1) {
+      const result = isPunctuation(randomChars.charAt(index));
+      expect(result).toBe(false);
+    }
+  });
+});
+
+describe('utilities - test whether a string starts with a value in a set', () => {
+  it('should return the match if the string begins with a value from a set', () => {
+    const matches = ['hello', 'start', 'begin'];
+    const strings = ['hello world', 'start here', 'begin with this'];
+
+    for (let index = 0; index < matches.length; index += 1) {
+      const expectedMatch = matches[index];
+      const searchString = strings[index];
+
+      const actual = getValueStartedWith(searchString, matches);
+
+      expect(actual).toBe(expectedMatch);
+    }
+  });
+
+  it('should not return the match if the string contains a value from a set', () => {
+    const matches = ['hello', 'start', 'begin'];
+    const strings = ['hello world', 'start here', 'begin with this'];
+    const prefix = 'Loads of words';
+
+    for (let index = 0; index < matches.length; index += 1) {
+      const searchString = `${prefix} ${strings[index]}`;
+
+      const actual = getValueStartedWith(searchString, matches);
+
+      expect(actual).toBeUndefined();
+    }
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,21 @@
+export function isCharacterInRegex(character: string, regex: RegExp): boolean {
+  if (typeof character !== 'string' || character.length !== 1) {
+    return false;
+  }
+
+  return regex.test(character.charAt(0));
+}
+
+export function isPunctuation(character: string): boolean {
+  return isCharacterInRegex(character, /[.,:;!?]/);
+}
+
+export function getValueStartedWith(
+  haystack: string,
+  needles: string[]
+): string {
+  const loweredHaystack = haystack.toLowerCase();
+  return needles.find((needle: string) =>
+    loweredHaystack.startsWith(needle.toLowerCase())
+  );
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "tslint-config-airbnb",
   "rules": {
+    "align": [true, "statements", "members", "elements"],
     "trailing-comma": [true, "never"]
   }
 }


### PR DESCRIPTION
This change set adds logic to the bot to enable detection of messages which address it.

Messages which count as “addressed” begin with the bot’s user name, the discord ID format or one of the “attention grabber” wake words (ok, okay, hey) followed by the bot’s name. Basic punctuation after these prefixes is also taken into account.

In summary, this means the following messages count as addressed:

- `bot hello`
-`bot, hello`
- `<@botId> hello`
- `ok bot, hello`
- `hey bot, hello`

This could be improved with a RegEx expression in the future depending on how performant the logic needs to be.