### PR TITLE
Add an extremely basic core that can give virtual items on command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,13 @@ import { Engine } from './interfaces/engine';
 
 import { BasicIntelligence } from './personality/basic-intelligence';
 import { GameElements } from './personality/game-elements';
+import { HugBot } from './personality/hug-bot';
 
 const botEngine = container.get<Engine>(TYPES.Engine);
 
 // TODO: dep injection
 botEngine.addPersonality(new BasicIntelligence());
 botEngine.addPersonality(new GameElements());
+botEngine.addPersonality(new HugBot());
 
 botEngine.run();

--- a/src/personality/hug-bot.spec.ts
+++ b/src/personality/hug-bot.spec.ts
@@ -1,0 +1,65 @@
+import { IMock, Mock } from 'typemoq';
+import { HugBot } from './hug-bot';
+import { Message, User } from 'discord.js';
+
+describe('Hugbot', () => {
+  const authorId = 'AUTHID';
+  const userToAddress = '<@ADDRESSED>';
+
+  let message: IMock<Message>;
+  let author: IMock<User>;
+
+  beforeEach(() => {
+    author =  Mock.ofType<User>();
+    author.setup(m => m.id).returns(() => authorId);
+
+    message = Mock.ofType<Message>();
+    message.setup(m => m.author).returns(() => author.object);
+  });
+
+  it('should not handle an addressed message', (done: DoneFn) => {
+    message.setup(m => m.content).returns(() => 'anything');
+
+    const core = new HugBot();
+
+    core.onAddressed(message.object, 'anything').then((result: string) => {
+      expect(result).toBe(null);
+      done();
+    });
+  });
+
+  it('should give an item to a user', () => {
+    const command = 'cmd';
+    const item = 'spoopy';
+    message.setup(m => m.content).returns(() => `!${command} ${userToAddress}`);
+
+    const core = new HugBot();
+
+    const untypedCore = core as any;
+    const response = untypedCore.response(message.object, command, item);
+
+    expect(response).toBe(`Gives a ${item} to ${userToAddress} from <@${authorId}>`);
+  });
+
+  it('should hug on !hug command', (done: DoneFn) => {
+    message.setup(m => m.content).returns(() => `!hug ${userToAddress}`);
+
+    const core = new HugBot();
+
+    core.onMessage(message.object).then((result: string) => {
+      expect(result).toBe(`Gives a hug to ${userToAddress} from <@${authorId}>`);
+      done();
+    });
+  });
+
+  it('should give a cake with emoji on !cake command', (done: DoneFn) => {
+    message.setup(m => m.content).returns(() => `!cake ${userToAddress}`);
+
+    const core = new HugBot();
+
+    core.onMessage(message.object).then((result: string) => {
+      expect(result).toBe(`Gives a 🎂 to ${userToAddress} from <@${authorId}>`);
+      done();
+    });
+  });
+});

--- a/src/personality/hug-bot.ts
+++ b/src/personality/hug-bot.ts
@@ -1,0 +1,52 @@
+import * as discord from 'discord.js';
+import { Personality } from '../interfaces/personality';
+
+export class HugBot implements Personality {
+  public onAddressed(
+    message: discord.Message,
+    addressedMessage: string
+  ): Promise<string> {
+    return Promise.resolve(null);
+  }
+
+  public onMessage(message: discord.Message): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const send = (message: string) => {
+        if (message === null) {
+          return;
+        }
+
+        resolve(message);
+      };
+
+      send(this.response(message, 'hug'));
+      send(this.response(message, 'cake', '🎂'));
+      send(this.response(message, 'pizza', '🍕'));
+      send(this.response(message, 'burger', '🍔'));
+      send(this.response(message, 'beer', '🍺'));
+      send(this.response(message, 'cookie', '🍪'));
+
+      resolve(null);
+    });
+  }
+
+  private response(message: discord.Message, command: string, itemOverride?: string): string {
+    if (!message.content.startsWith(`!${command}`)) {
+      return null;
+    }
+
+    let item;
+    if (!itemOverride) {
+      item = command;
+    } else {
+      item = itemOverride;
+    }
+
+    const bits = message.content.split(' ');
+    if (bits[1].startsWith('<@') && bits[1].endsWith('>')) {
+      return `Gives a ${item} to ${bits[1]} from <@${message.author.id}>`;
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
This personality core emulates the popular HugBot on the LoadingArtist discord server.

To use it, simply issue `!hug @user` (use the autocomplete to choose the user).

One can also give basic foodstuffs using `!cake`, `!cookie`, `!pizza` etc.