### PR TITLE
Add a dummy addressed message fallback for the bot

### DIFF
--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -85,9 +85,17 @@ export class BotEngine implements Engine {
 
   private calculateAddressedMessage(message: discord.Message): string {
     const botInfo = this.client.getUserInformation();
-    const username = botInfo.username;
-    const botId = `<@${botInfo.id}>`;
-    const messageText = message.content.replace(botId, username);
+    let username = botInfo.username;
+
+    // If the bot is in a "server" but has been renamed, update the value of the username
+    const guildMemberInfo = message.guild.members.get(botInfo.id);
+    if (guildMemberInfo && guildMemberInfo.nickname.length > 0) {
+      username = guildMemberInfo.nickname;
+    }
+
+    const atUsername = `@${username}`;
+    const botId = `<@!${botInfo.id}>`;
+    const messageText = message.content.replace(botId, username).replace(atUsername, username);
 
     const lowercaseMessage = messageText.toLowerCase();
     const lowercaseUsername = username.toLowerCase();


### PR DESCRIPTION
This change allows the bot to always have a response if it is addressed, as the slack version of the bot originally did.

It also fixes the algorithm for detecting it has been addressed – using `<@!id>` over `<@id>`