### PR TITLE
Lay the groundwork for randomised responses using a database backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,49 @@ Discord version of my slack chatbot, rewritten from the ground up
 1. Install Node. The LTS version should be fine. 
 2. `npm run quickstart` fetches dependencies, builds and then runs the bot using the start entry point.
  
-# Developing 
+## Developing 
 1. `npm run develop` spins up a live-reload instance of the bot. Every time you change a file and save it, the bot will restart with the latest changes
+
+## Responses
+In some instances, the bot can respond with a canned response from a phrase set. It does this with the help of a SQLite database.
+
+In order to initialize the database with the correct table structure, run the following SQL statement:
+
+```sql
+CREATE TABLE `responses` ( `type` TEXT, `mood` TEXT, `text` TEXT )
+```
+
+- `type` is the name of the phrase set this response belongs to, and is the identifier used in-code to fetch a phrase.
+- `mood` is the general tone of voice of this phrase, and will be used to vary the responses based upon the bot's mood. Currently, only 'none' is supported.
+- `text` is the actual textual content of the response.
+
+For example, there may be a phrase set used to welcome new people to the server titled `'welcome'`. It could contain the following entries:
+```json
+[
+  { "type": "welcome", "mood": "none", "text": "hey!" },
+  { "type": "welcome", "mood": "none", "text": "hi" },
+  { "type": "welcome", "mood": "none", "text": "welcome" },
+]
+```
+
+When the bot uses the `'welcome'` phrase set, the resulting message may be either "hey!", "hi" or "welcome".
+
+To use this feature in your personality constructs, grab the singleton instance of the class implementing `ResponseGenerator` using dependency injection or getting the value from the container itself.
+
+```typescript
+class myPersonality implements Personality {
+
+  // Injected into the constructor - use this.responses.generateResponse('phrase') elsewhere in the class
+  constructor(@inject(TYPES.ResponseGenerator) private responses: ResponseGenerator) {}
+
+  // Used by getting the value from the container
+  function myResponse(message: discord.Message): Promise<string> {
+    if (message.content === '!command') {
+      const responseGen = container.get<ResponseGenerator>(TYPES.ResponseGenerator);
+      return responseGen.generateResponse('my-phrase-here');
+    }
+
+    return Promise.resolve(null);
+  }
+}
+```

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,4 +1,6 @@
 export const TYPES = {
   Client: Symbol.for('Client'),
   Engine: Symbol.for('Engine'),
+  Database: Symbol.for('Database'),
+  ResponseGenerator: Symbol.for('ResponseGenerator')
 };

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -8,6 +8,7 @@ import { Client } from '../interfaces/client';
 import { Engine } from '../interfaces/engine';
 import { Personality } from '../interfaces/personality';
 import { getValueStartedWith, isPunctuation } from '../utils';
+import { ResponseGenerator } from '../interfaces/response-generator';
 
 const token = ''; // DO NOT SUBMIT
 
@@ -15,7 +16,10 @@ const token = ''; // DO NOT SUBMIT
 export class BotEngine implements Engine {
   private personalityConstructs: Personality[];
 
-  constructor(@inject(TYPES.Client) private client: Client) {
+  constructor(
+    @inject(TYPES.Client) private client: Client,
+    @inject(TYPES.ResponseGenerator) private responses: ResponseGenerator
+  ) {
     this.personalityConstructs = [];
   }
 
@@ -78,7 +82,10 @@ export class BotEngine implements Engine {
     );
     this.dequeuePromises(funcs)
       .then(() => {
-        this.client.queueMessages(['Unhandled addressed message (yeah I\'m totally a bot)']);
+        return this.responses.generateResponse('addressedGeneric')
+          .then((response: string) => {
+            this.client.queueMessages([response]);
+          });
       })
       .catch((err: any) => console.error(err));
   }

--- a/src/engine/sqlite-wrapper.spec.ts
+++ b/src/engine/sqlite-wrapper.spec.ts
@@ -102,7 +102,7 @@ describe('SQLite wrapper', () => {
   it('should handle error returned from getting a collection', (done: DoneFn) => {
     const expectedError = 'ERROR';
     mockStatement
-      .setup(m => m.get(It.isAny(), It.isAny()))
+      .setup(m => m.all(It.isAny(), It.isAny()))
       .callback((filter: any, cb: Function) => {
         cb(new Error(expectedError));
       });
@@ -123,7 +123,7 @@ describe('SQLite wrapper', () => {
     const expectedCollection = 'myCollection';
     const mockRows = [{ id: 0 }, { id: 1 }];
     mockStatement
-      .setup(m => m.get(It.isAny(), It.isAny()))
+      .setup(m => m.all(It.isAny(), It.isAny()))
       .callback((filter: any, cb: Function) => {
         cb(null, mockRows);
       });
@@ -147,7 +147,7 @@ describe('SQLite wrapper', () => {
   it('should correctly build SQL statement when filter has been applied', (done: DoneFn) => {
     const filter = { a: 'a', b: 'b' };
     mockStatement
-      .setup(m => m.get(It.isAny(), It.isAny()))
+      .setup(m => m.all(It.isAny(), It.isAny()))
       .callback((filter: any, cb: Function) => {
         cb(null, []);
       });

--- a/src/engine/sqlite-wrapper.ts
+++ b/src/engine/sqlite-wrapper.ts
@@ -1,8 +1,10 @@
 import { Database } from '../interfaces/database';
 import * as sqlite from 'sqlite3';
+import { injectable } from 'inversify';
 
 const databaseFile = './bot.sqlite';
 
+@injectable()
 export class SqliteWrapper implements Database {
   private db: sqlite.Database;
 

--- a/src/engine/sqlite-wrapper.ts
+++ b/src/engine/sqlite-wrapper.ts
@@ -45,13 +45,16 @@ export class SqliteWrapper implements Database {
     const objKeys = Object.keys(filter);
     const comparisonOp = '=?';
     let where = objKeys.join(`${comparisonOp} AND `);
+    let vals: any[] = [];
     if (where.length > 0) {
       where = ` WHERE ${where}${comparisonOp}`;
+      vals = objKeys.map((key: string) => filter[key]);
     }
 
     return new Promise((resolve, reject) => {
-      const statement = this.db.prepare(`SELECT * FROM ${collectionName}${where}`);
-      statement.get(filter, (err: Error, rows: any) => {
+      const sql = `SELECT * FROM ${collectionName}${where}`;
+      const statement = this.db.prepare(sql);
+      statement.all(vals, (err: Error, rows: any) => {
         statement.finalize();
 
         if (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,13 @@ import { Engine } from './interfaces/engine';
 import { BasicIntelligence } from './personality/basic-intelligence';
 import { GameElements } from './personality/game-elements';
 import { HugBot } from './personality/hug-bot';
+import { Database } from './interfaces/database';
 
 const botEngine = container.get<Engine>(TYPES.Engine);
+const db = container.get<Database>(TYPES.Database);
+db.connect().then(() => {
+  console.log('Database connected');
+});
 
 // TODO: dep injection
 botEngine.addPersonality(new BasicIntelligence());
@@ -16,3 +21,8 @@ botEngine.addPersonality(new GameElements());
 botEngine.addPersonality(new HugBot());
 
 botEngine.run();
+
+process.on('beforeExit', () => {
+  console.log('Disconnecting database');
+  db.disconnect();
+});

--- a/src/infrastructure/installer.ts
+++ b/src/infrastructure/installer.ts
@@ -5,7 +5,15 @@ import { Client } from '../interfaces/client';
 import { DiscordClient } from '../client/discord-client';
 import { Engine } from '../interfaces/engine';
 import { BotEngine } from '../engine/bot-engine';
+import { Database } from '../interfaces/database';
+import { SqliteWrapper } from '../engine/sqlite-wrapper';
+import { ResponseGenerator } from '../interfaces/response-generator';
+import { ResponseGeneratorImpl } from '../personality/response-generator-impl';
 
 export const container = new Container();
-container.bind<Client>(TYPES.Client).to(DiscordClient);
-container.bind<Engine>(TYPES.Engine).to(BotEngine);
+container.bind<Client>(TYPES.Client).to(DiscordClient).inSingletonScope();
+container.bind<Engine>(TYPES.Engine).to(BotEngine).inSingletonScope();
+container.bind<Database>(TYPES.Database).to(SqliteWrapper).inSingletonScope();
+container.bind<ResponseGenerator>(TYPES.ResponseGenerator)
+  .to(ResponseGeneratorImpl)
+  .inSingletonScope();

--- a/src/interfaces/response-generator.ts
+++ b/src/interfaces/response-generator.ts
@@ -1,3 +1,3 @@
 export interface ResponseGenerator {
-  generateResponse(phrase: string): string;
+  generateResponse(phrase: string): Promise<string>;
 }

--- a/src/interfaces/response-generator.ts
+++ b/src/interfaces/response-generator.ts
@@ -1,0 +1,3 @@
+export interface ResponseGenerator {
+  generateResponse(phrase: string): string;
+}

--- a/src/personality/response-generator-impl.spec.ts
+++ b/src/personality/response-generator-impl.spec.ts
@@ -1,0 +1,16 @@
+import { ResponseGeneratorImpl } from './response-generator-impl';
+
+describe('response generator', () => {
+  it('should create', () => {
+    const gen = new ResponseGeneratorImpl();
+    expect(gen).toBeTruthy();
+  });
+
+  it('should generate a response for a phrase', () => {
+    const gen = new ResponseGeneratorImpl();
+
+    const actualResponse = gen.generateResponse('phrase');
+
+    expect(actualResponse).toBe('');
+  });
+});

--- a/src/personality/response-generator-impl.spec.ts
+++ b/src/personality/response-generator-impl.spec.ts
@@ -1,16 +1,37 @@
+import { IMock, Mock, It, Times } from 'typemoq';
+import { Database } from '../interfaces/database';
+
 import { ResponseGeneratorImpl } from './response-generator-impl';
 
+const mockDbRows = [
+  { text: 'a' },
+  { text: 'b' },
+  { text: 'c' }
+];
+
 describe('response generator', () => {
+  let database: IMock<Database>;
+
+  beforeEach(() => {
+    database = Mock.ofType<Database>();
+    database
+      .setup(m => m.getRecordsFromCollection(It.isAnyString(), It.isAny()))
+      .returns((collection: string) => Promise.resolve(mockDbRows));
+  });
+
   it('should create', () => {
-    const gen = new ResponseGeneratorImpl();
+    const gen = new ResponseGeneratorImpl(database.object);
     expect(gen).toBeTruthy();
   });
 
-  it('should generate a response for a phrase', () => {
-    const gen = new ResponseGeneratorImpl();
+  it('should generate a response for a phrase', (done: DoneFn) => {
+    const gen = new ResponseGeneratorImpl(database.object);
 
-    const actualResponse = gen.generateResponse('phrase');
-
-    expect(actualResponse).toBe('');
+    gen.generateResponse('phrase').then((response: string) => {
+      // Verify that the result is equal to one of the texts in the rows
+      const mappedToMockRow = mockDbRows.find(x => x.text === response);
+      expect(mappedToMockRow).toBeTruthy();
+      done();
+    });
   });
 });

--- a/src/personality/response-generator-impl.spec.ts
+++ b/src/personality/response-generator-impl.spec.ts
@@ -14,9 +14,6 @@ describe('response generator', () => {
 
   beforeEach(() => {
     database = Mock.ofType<Database>();
-    database
-      .setup(m => m.getRecordsFromCollection(It.isAnyString(), It.isAny()))
-      .returns((collection: string) => Promise.resolve(mockDbRows));
   });
 
   it('should create', () => {
@@ -25,12 +22,29 @@ describe('response generator', () => {
   });
 
   it('should generate a response for a phrase', (done: DoneFn) => {
+    database
+      .setup(m => m.getRecordsFromCollection(It.isAnyString(), It.isAny()))
+      .returns((collection: string) => Promise.resolve(mockDbRows));
+
     const gen = new ResponseGeneratorImpl(database.object);
 
     gen.generateResponse('phrase').then((response: string) => {
       // Verify that the result is equal to one of the texts in the rows
       const mappedToMockRow = mockDbRows.find(x => x.text === response);
       expect(mappedToMockRow).toBeTruthy();
+      done();
+    });
+  });
+
+  it('should return an empty string if no rows are returned from the database', (done: DoneFn) => {
+    database
+      .setup(m => m.getRecordsFromCollection(It.isAnyString(), It.isAny()))
+      .returns((collection: string) => Promise.resolve([]));
+
+    const gen = new ResponseGeneratorImpl(database.object);
+
+    gen.generateResponse('phrase').then((response: string) => {
+      expect(response).toBe('');
       done();
     });
   });

--- a/src/personality/response-generator-impl.ts
+++ b/src/personality/response-generator-impl.ts
@@ -1,0 +1,7 @@
+import { ResponseGenerator } from '../interfaces/response-generator';
+
+export class ResponseGeneratorImpl implements ResponseGenerator {
+  public generateResponse(phrase: string): string {
+    return '';
+  }
+}

--- a/src/personality/response-generator-impl.ts
+++ b/src/personality/response-generator-impl.ts
@@ -11,7 +11,7 @@ export class ResponseGeneratorImpl implements ResponseGenerator {
   constructor(@inject(TYPES.Database) private database: Database) {}
 
   public async generateResponse(phrase: string): Promise<string> {
-    const filter = { responseType: phrase };
+    const filter = { type: phrase, mood: 'none' };
     const responses = await this.database.getRecordsFromCollection(collectionName, filter);
     if (responses.length === 0) {
       return '';

--- a/src/personality/response-generator-impl.ts
+++ b/src/personality/response-generator-impl.ts
@@ -1,7 +1,20 @@
 import { ResponseGenerator } from '../interfaces/response-generator';
+import { Database } from '../interfaces/database';
+import { randomNumber } from '../utils';
+
+const collectionName = 'responses';
 
 export class ResponseGeneratorImpl implements ResponseGenerator {
-  public generateResponse(phrase: string): string {
-    return '';
+  constructor(private database: Database) {}
+
+  public async generateResponse(phrase: string): Promise<string> {
+    const filter = { responseType: phrase };
+    const responses = await this.database.getRecordsFromCollection(collectionName, filter);
+    if (responses.length === 0) {
+      return '';
+    }
+
+    const choice = randomNumber(responses.length);
+    return responses[choice].text;
   }
 }

--- a/src/personality/response-generator-impl.ts
+++ b/src/personality/response-generator-impl.ts
@@ -1,11 +1,14 @@
 import { ResponseGenerator } from '../interfaces/response-generator';
 import { Database } from '../interfaces/database';
 import { randomNumber } from '../utils';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../constants/types';
 
 const collectionName = 'responses';
 
+@injectable()
 export class ResponseGeneratorImpl implements ResponseGenerator {
-  constructor(private database: Database) {}
+  constructor(@inject(TYPES.Database) private database: Database) {}
 
   public async generateResponse(phrase: string): Promise<string> {
     const filter = { responseType: phrase };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,17 @@ export function getValueStartedWith(
     loweredHaystack.startsWith(needle.toLowerCase())
   );
 }
+
+/**
+ * Central location for random number generation.
+ */
+export function randomNumber(min: number, max?: number): number {
+  let minimum = min;
+  let maximum = max;
+  if (typeof max === 'undefined') {
+    minimum = 0;
+    maximum = min;
+  }
+
+  return Math.floor(Math.random() * (maximum - minimum)) + minimum;
+}


### PR DESCRIPTION
This change set lays the initial groundwork for creating variations in responses. It does so by selecting from a set of canned responses that are stored in a database.

In order to do this, the database (SQLite) wrapper was added to the dependency injection framework and is used to select a canned string from the `responses` collection by the response generator. The responses collection is a set of records containing 'type', 'mood' and 'text' string data:
- 'type' is the name of the phrase set this record belongs to.
- 'mood' is the tone of the message and will be utilised in further work. For now, only 'none' is recognised.
- 'text' is the response.

A bug in the SQLite wrapper was also fixed: it now uses `.all` as opposed to `.get` to ensure all rows are returned.