### PR TITLE
Add SQLite database files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ typings/
 dist
 
 \.DS_Store
+
+*.sqlite


### PR DESCRIPTION
This change set prevents SQLite databases from being added to the repository by placing the extension into the ignore file. 