### PR TITLE
Disconnect cleanly from web services on exit

### DIFF
--- a/src/engine/bot-engine.spec.ts
+++ b/src/engine/bot-engine.spec.ts
@@ -202,6 +202,19 @@ describe('Bot engine', () => {
     expect(destroySpy).toHaveBeenCalled();
   });
 
+  it('should disconnect on destroy', () => {
+    const engine = new BotEngine(
+      client.object,
+      responseGenerator.object,
+      settings.object,
+      console
+    );
+
+    engine.destroy();
+
+    client.verify((c) => c.disconnect(), Times.once());
+  });
+
   it('should handle ambient messages when message received', () => {
     const engine = new BotEngine(
       client.object,

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -43,6 +43,8 @@ export class BotEngine implements Engine {
         personality.destroy();
       }
     });
+
+    this.client.disconnect();
   }
 
   public run(): void {
@@ -58,7 +60,7 @@ export class BotEngine implements Engine {
   }
 
   private onConnected(): void {
-    this.logger.log('Connected');
+    this.logger.log('Connected to Discord services');
   }
 
   private onMessage(message: discord.Message): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { SimpleInteractions } from './personality/simple-interactions';
 
 // Initialise foundation
 const logger = new LoggerImpl();
-const database = new SqliteWrapper();
+const database = new SqliteWrapper(logger);
 database.connect().then(() => {
   logger.log('Database connected');
 });


### PR DESCRIPTION
TLDR: This set of changes ensures the bot disconnects from web services when it is closed so that it does not stay in memory or have the database connection active. I've also added logging output to the SQLite wrapper.

There was an issue where if the bot was closed using SIGINT or similar, it would remain connected to the Discord services indefinitely (as seen in the user list) and the database connection remained active during this time. This could cause issues if a new instance of the bot was started while the previously-quit instance was still connected, resulting in invalid logs being generated about the database connection failing.