### PR TITLE
Allow call-response patterns that address the bot

### DIFF
--- a/src/personality/call-response.ts
+++ b/src/personality/call-response.ts
@@ -20,15 +20,20 @@ export class CallResponse implements Personality {
     message: Message,
     addressedMessage: string
   ): Promise<string> {
-    return Promise.resolve(null);
+    const callString = `{£me} ${addressedMessage}`;
+    return this.generateResponseIfFound(callString);
   }
 
   public onMessage(message: Message): Promise<string> {
+    return this.generateResponseIfFound(message.content);
+  }
+
+  private generateResponseIfFound(call: string): Promise<string> {
     const filter = {
       where: [
         {
           field: 'call',
-          value: message.content
+          value: call
         }
       ]
     };


### PR DESCRIPTION
This enables call/response patterns that address the bot. They are stored in the call/response table with the prefix `'{£me} <call text>'`. The address logic uses the standard bot attention grabber phrases.

# Example
Table `call_response`
| call | response |
|-|-|
| `{£me} wake word text` | `Generated text response!` |

One can then use an attention grabber in the chat with the phrase:

```
user:    hey irisbot, wake word text
irisbot: Generated text response!
```