### PR TITLE
Convert exit handler to use node-cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,6 +476,12 @@
       "integrity": "sha512-G0lD1/7qD60TJ/mZmhog76k7NcpLWkPVGgzkRy3CTlnFu4LUQh5v2Wa661z6vnXmD8EQrnALUyf0VRtrACYztw==",
       "dev": true
     },
+    "@types/node-cleanup": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node-cleanup/-/node-cleanup-2.1.1.tgz",
+      "integrity": "sha512-Q1s5Sszz6YfhaGr1pbaZihr9IYaiQT0aOK/3c2qb9lOUbEBhcAb9ZEU7RBTtopnHSIJF80adLRcOGTay2W5QVQ==",
+      "dev": true
+    },
     "@types/node-fetch": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
@@ -2781,6 +2787,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
       "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+    },
+    "node-cleanup": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw="
     },
     "node-fetch": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
   "homepage": "https://github.com/jbrowneuk/iris-bot#readme",
   "dependencies": {
     "discord.js": "12.5.1",
+    "node-cleanup": "^2.1.2",
     "node-fetch": "2.6.1",
     "sqlite3": "5.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^3.6.2",
     "@types/node": "^14.14.7",
+    "@types/node-cleanup": "^2.1.1",
     "@types/node-fetch": "^2.5.7",
     "@types/sqlite3": "^3.1.6",
     "@types/ws": "^7.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import { HugBot } from './personality/hug-bot';
 import { MoodControl } from './personality/mood-control';
 import { SimpleInteractions } from './personality/simple-interactions';
 
+import * as nodeCleanup from 'node-cleanup';
+
 // Initialise foundation
 const logger = new LoggerImpl();
 const database = new SqliteWrapper(logger);
@@ -28,8 +30,7 @@ function destroyHandler(): void {
   database.disconnect();
 }
 
-process.on('beforeExit', destroyHandler);
-process.on('SIGINT', destroyHandler);
+nodeCleanup(destroyHandler);
 
 // Initialise bot core
 const client = new DiscordClient(logger);


### PR DESCRIPTION
This changeset converts the cleanup handlers to use the node-cleanup so it works properly when run as a service on the Pi.