### PR TITLE
Improve parsing of git commit for readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Discord chatbot",
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",


### PR DESCRIPTION
This changes the prebuild script to output a more consistent `git-commit` stamp for the bot to use in the `+buildInfo` command:
- Removes all `origin/` branches for easier readability
- Uses `%ai` as opposed to `%as` for commit author date