### PR TITLE
Implement help system for bot personality plugins

### DIFF
--- a/src/client/discord-client.spec.ts
+++ b/src/client/discord-client.spec.ts
@@ -24,13 +24,20 @@ MOCK_CHANNELS.set(MOCK_CHAN_2_ID, {
   name: MOCK_CHAN_2_NAME
 });
 
+const MOCK_BOT_USERNAME = 'mock-bot';
+
 describe('Discord client wrapper', () => {
   let discordMock: IMock<discord.Client>;
+  let clientUserMock: IMock<discord.ClientUser>;
   let client: DiscordClient;
   let mockChannels: IMock<discord.ChannelManager>;
 
   beforeEach(() => {
+    clientUserMock = Mock.ofType<discord.ClientUser>();
+    clientUserMock.setup((u) => u.username).returns(() => MOCK_BOT_USERNAME);
+
     discordMock = Mock.ofType<discord.Client>();
+    discordMock.setup((s) => s.user).returns(() => clientUserMock.object);
 
     mockChannels = Mock.ofType<discord.ChannelManager>();
     mockChannels
@@ -41,230 +48,240 @@ describe('Discord client wrapper', () => {
     spyOn(client as any, 'generateClient').and.returnValue(discordMock.object);
   });
 
-  it('should connect with token', () => {
-    discordMock.setup((m) => m.login(It.isAnyString()));
+  describe('not connected state', () => {
+    it('should connect with token', () => {
+      discordMock.setup((m) => m.login(It.isAnyString()));
 
-    client.connect(MOCK_TOKEN);
+      client.connect(MOCK_TOKEN);
 
-    discordMock.verify((m) => m.login(It.isValue(MOCK_TOKEN)), Times.once());
-  });
+      discordMock.verify((m) => m.login(It.isValue(MOCK_TOKEN)), Times.once());
+    });
 
-  it('should disconnect if connected', () => {
-    (client as any).client = discordMock.object; // This is set when connected
-    discordMock.setup((m) => m.destroy());
+    it('should initialise event listeners on connect', () => {
+      client.connect(MOCK_TOKEN);
 
-    client.disconnect();
+      // Connected and message
+      discordMock.verify(
+        (m) => m.on(It.isValue(readyEvent), It.isAny()),
+        Times.once()
+      );
+      discordMock.verify(
+        (m) => m.on(It.isValue(messageEvent), It.isAny()),
+        Times.once()
+      );
+    });
 
-    discordMock.verify((m) => m.destroy(), Times.once());
-  });
+    it('should add connection event handler on connection', () => {
+      const untypedClient = client as any;
+      spyOn(untypedClient, 'onConnected');
+      const callbacks: Array<{ evt: string; cb: () => void }> = [];
+      discordMock
+        .setup((m) => m.on(It.isAny(), It.isAny()))
+        .callback((evt: string, cb: () => void) => {
+          callbacks.push({ evt, cb });
+        });
 
-  it('should initialise event listeners on connect', () => {
-    // discordMock.setup(m => m.on(It.isAny(), It.isAny()));
+      client.connect(MOCK_TOKEN);
 
-    client.connect(MOCK_TOKEN);
+      const relatedHandler = callbacks.find((cb) => cb.evt === readyEvent);
+      relatedHandler.cb.call(client);
 
-    // Connected and message
-    discordMock.verify(
-      (m) => m.on(It.isValue(readyEvent), It.isAny()),
-      Times.once()
-    );
-    discordMock.verify(
-      (m) => m.on(It.isValue(messageEvent), It.isAny()),
-      Times.once()
-    );
-  });
+      expect(untypedClient.onConnected).toHaveBeenCalled();
+    });
 
-  it('should add connection event handler on connection', () => {
-    const untypedClient = client as any;
-    spyOn(untypedClient, 'onConnected');
-    const callbacks: Array<{ evt: string; cb: () => void }> = [];
-    discordMock
-      .setup((m) => m.on(It.isAny(), It.isAny()))
-      .callback((evt: string, cb: () => void) => {
-        callbacks.push({ evt, cb });
-      });
+    it('should add message event handler on connection', () => {
+      const untypedClient = client as any;
+      spyOn(untypedClient, 'onMessage');
+      const callbacks: Array<{ evt: string; cb: () => void }> = [];
+      discordMock
+        .setup((m) => m.on(It.isAny(), It.isAny()))
+        .callback((evt: string, cb: () => void) => {
+          callbacks.push({ evt, cb });
+        });
 
-    client.connect(MOCK_TOKEN);
+      client.connect(MOCK_TOKEN);
 
-    const relatedHandler = callbacks.find((cb) => cb.evt === readyEvent);
-    relatedHandler.cb.call(client);
+      const relatedHandler = callbacks.find((cb) => cb.evt === messageEvent);
+      relatedHandler.cb.call(client);
 
-    expect(untypedClient.onConnected).toHaveBeenCalled();
-  });
-
-  it('should add message event handler on connection', () => {
-    const untypedClient = client as any;
-    spyOn(untypedClient, 'onMessage');
-    const callbacks: Array<{ evt: string; cb: () => void }> = [];
-    discordMock
-      .setup((m) => m.on(It.isAny(), It.isAny()))
-      .callback((evt: string, cb: () => void) => {
-        callbacks.push({ evt, cb });
-      });
-
-    client.connect(MOCK_TOKEN);
-
-    const relatedHandler = callbacks.find((cb) => cb.evt === messageEvent);
-    relatedHandler.cb.call(client);
-
-    expect(untypedClient.onMessage).toHaveBeenCalled();
-  });
-
-  it('should find channel by id', () => {
-    (client as any).client = discordMock.object; // This is set when connected
-    discordMock.setup((m) => m.channels).returns(() => mockChannels.object);
-
-    const channel = client.findChannelById(MOCK_CHAN_1_ID);
-
-    // It's not possible to mock channels using their type definition
-    expect((channel as any).name).toBe(MOCK_CHAN_1_NAME);
-  });
-
-  it('should return null if cannot find channel by id', () => {
-    (client as any).client = discordMock.object; // This is set when connected
-    discordMock.setup((m) => m.channels).returns(() => mockChannels.object);
-
-    const channel = client.findChannelById('SomethingThatDoesNotExist');
-
-    expect(channel).toBeNull();
-  });
-
-  it('should queue messages', () => {
-    const untypedClient = client as any;
-    spyOn(untypedClient, 'sendMessage');
-
-    const messages = ['one', 'two', 'three'];
-    client.queueMessages(messages);
-
-    expect(untypedClient.sendMessage).toHaveBeenCalledTimes(messages.length);
-  });
-
-  it('should send queued messages', () => {
-    let sendCount = 0;
-    const mockChannel = {
-      send: (message: string) => {
-        sendCount += 1;
-      }
-    };
-    const untypedClient = client as any;
-    untypedClient.lastMessage = { channel: mockChannel };
-
-    const messages = ['one', 'two', 'three'];
-    client.queueMessages(messages);
-
-    expect(sendCount).toBe(3);
-  });
-
-  it('should replace user string with last message user name', () => {
-    const expectedName = 'bob-bobertson';
-    let lastMessage: string = null;
-    const mockChannel = {
-      send: (message: string) => (lastMessage = message)
-    };
-    const untypedClient = client as any;
-    untypedClient.lastMessage = {
-      channel: mockChannel,
-      author: { username: expectedName }
-    };
-
-    const messages = ['{£user} {£user} {£user}'];
-    client.queueMessages(messages);
-
-    expect(lastMessage).toBe(`${expectedName} ${expectedName} ${expectedName}`);
-  });
-
-  it('should get user information', () => {
-    const username = 'test';
-    const mockUserInfo = Mock.ofType<discord.ClientUser>();
-    mockUserInfo.setup((m) => m.username).returns(() => username);
-    (client as any).client = discordMock.object; // This is set when connected
-    discordMock.setup((m) => m.user).returns(() => mockUserInfo.object);
-
-    const user = client.getUserInformation();
-
-    expect(user.username).toBe(username);
-  });
-
-  it('should get online status', () => {
-    const states = [true, false];
-    states.forEach((state: boolean) => {
-      (client as any).connected = state;
-      expect(client.isConnected()).toBe(state);
+      expect(untypedClient.onMessage).toHaveBeenCalled();
     });
   });
 
-  it('should handle connection event', () => {
-    let eventRaised = false;
-    const callbacks: Array<{ evt: string; cb: () => void }> = [];
-    discordMock
-      .setup((m) => m.on(It.isAny(), It.isAny()))
-      .callback((evt: string, cb: () => void) => {
-        callbacks.push({ evt, cb });
-      });
-    client.on(LifecycleEvents.CONNECTED, () => {
-      eventRaised = true;
+  describe('connected state', () => {
+    beforeEach(() => {
+      (client as any).client = discordMock.object; // This is set when connected
     });
 
-    client.connect(MOCK_TOKEN);
+    it('should disconnect if connected', () => {
+      discordMock.setup((m) => m.destroy());
 
-    const relatedHandler = callbacks.find((cb) => cb.evt === readyEvent);
-    relatedHandler.cb.call(client);
+      client.disconnect();
 
-    expect(eventRaised).toBeTruthy();
-  });
-
-  function messageHandlerTest(mockMessage: any): boolean {
-    let eventRaised = false;
-    const callbacks: Array<{ evt: string; cb: (a: any) => void }> = [];
-    discordMock
-      .setup((m) => m.on(It.isAny(), It.isAny()))
-      .callback((evt: string, cb: () => void) => {
-        callbacks.push({ evt, cb });
-      });
-    client.connect(MOCK_TOKEN);
-    client.on(LifecycleEvents.MESSAGE, () => {
-      eventRaised = true;
+      discordMock.verify((m) => m.destroy(), Times.once());
     });
 
-    const relatedHandler = callbacks.find((cb) => cb.evt === messageEvent);
-    relatedHandler.cb.call(client, mockMessage);
+    it('should find channel by id', () => {
+      discordMock.setup((m) => m.channels).returns(() => mockChannels.object);
 
-    return eventRaised;
-  }
+      const channel = client.findChannelById(MOCK_CHAN_1_ID);
 
-  it('should handle incoming message event from text channel', () => {
-    const mockMessage = {
-      channel: { type: 'text' },
-      content: 'text message',
-      user: {}
-    };
+      // It's not possible to mock channels using their type definition
+      expect((channel as any).name).toBe(MOCK_CHAN_1_NAME);
+    });
 
-    const eventRaised = messageHandlerTest(mockMessage);
-    expect(eventRaised).toBeTruthy();
-  });
+    it('should return null if cannot find channel by id', () => {
+      discordMock.setup((m) => m.channels).returns(() => mockChannels.object);
 
-  it('should not handle incoming message event from non-text channel', () => {
-    const mockMessage = {
-      channel: { type: 'dm' },
-      content: 'text message',
-      user: {}
-    };
+      const channel = client.findChannelById('SomethingThatDoesNotExist');
 
-    const eventRaised = messageHandlerTest(mockMessage);
-    expect(eventRaised).toBeFalsy();
-  });
+      expect(channel).toBeNull();
+    });
 
-  it('should set presence data', () => {
-    const mockUser = Mock.ofType<discord.ClientUser>();
-    discordMock.setup((m) => m.user).returns(() => mockUser.object);
-    const mockPresence = { activity: {} };
-    (client as any).client = discordMock.object; // This is set when connected
+    it('should queue messages', () => {
+      const untypedClient = client as any;
+      spyOn(untypedClient, 'sendMessage');
 
-    client.setPresence(mockPresence);
+      const messages = ['one', 'two', 'three'];
+      client.queueMessages(messages);
 
-    mockUser.verify(
-      (u) => u.setPresence(It.isValue(mockPresence)),
-      Times.once()
-    );
+      expect(untypedClient.sendMessage).toHaveBeenCalledTimes(messages.length);
+    });
+
+    it('should send queued messages', () => {
+      let sendCount = 0;
+      const mockChannel = {
+        send: (message: string) => {
+          sendCount += 1;
+        }
+      };
+      const untypedClient = client as any;
+      untypedClient.lastMessage = { channel: mockChannel };
+
+      const messages = ['one', 'two', 'three'];
+      client.queueMessages(messages);
+
+      expect(sendCount).toBe(3);
+    });
+
+    it('should replace user string with last message user name', () => {
+      const expectedName = 'bob-bobertson';
+      let lastMessage: string = null;
+      const mockChannel = {
+        send: (message: string) => (lastMessage = message)
+      };
+      const untypedClient = client as any;
+      untypedClient.lastMessage = {
+        channel: mockChannel,
+        author: { username: expectedName }
+      };
+
+      const messages = ['{£user} {£user} {£user}'];
+      client.queueMessages(messages);
+
+      expect(lastMessage).toBe(
+        `${expectedName} ${expectedName} ${expectedName}`
+      );
+    });
+
+    it('should replace name string with bot user name', () => {
+      let lastMessage: string = null;
+      const mockChannel = {
+        send: (message: string) => (lastMessage = message)
+      };
+      const untypedClient = client as any;
+      untypedClient.lastMessage = { channel: mockChannel };
+
+      const messages = ['{£me}'];
+      client.queueMessages(messages);
+
+      expect(lastMessage).toBe(MOCK_BOT_USERNAME);
+    });
+
+    it('should get user information', () => {
+      const user = client.getUserInformation();
+
+      expect(user.username).toBe(MOCK_BOT_USERNAME);
+    });
+
+    it('should get online status', () => {
+      const states = [true, false];
+      states.forEach((state: boolean) => {
+        (client as any).connected = state;
+        expect(client.isConnected()).toBe(state);
+      });
+    });
+
+    it('should handle connection event', () => {
+      let eventRaised = false;
+      const callbacks: Array<{ evt: string; cb: () => void }> = [];
+      discordMock
+        .setup((m) => m.on(It.isAny(), It.isAny()))
+        .callback((evt: string, cb: () => void) => {
+          callbacks.push({ evt, cb });
+        });
+      client.on(LifecycleEvents.CONNECTED, () => {
+        eventRaised = true;
+      });
+
+      client.connect(MOCK_TOKEN);
+
+      const relatedHandler = callbacks.find((cb) => cb.evt === readyEvent);
+      relatedHandler.cb.call(client);
+
+      expect(eventRaised).toBeTruthy();
+    });
+
+    function messageHandlerTest(mockMessage: any): boolean {
+      let eventRaised = false;
+      const callbacks: Array<{ evt: string; cb: (a: any) => void }> = [];
+      discordMock
+        .setup((m) => m.on(It.isAny(), It.isAny()))
+        .callback((evt: string, cb: () => void) => {
+          callbacks.push({ evt, cb });
+        });
+      client.connect(MOCK_TOKEN);
+      client.on(LifecycleEvents.MESSAGE, () => {
+        eventRaised = true;
+      });
+
+      const relatedHandler = callbacks.find((cb) => cb.evt === messageEvent);
+      relatedHandler.cb.call(client, mockMessage);
+
+      return eventRaised;
+    }
+
+    it('should handle incoming message event from text channel', () => {
+      const mockMessage = {
+        channel: { type: 'text' },
+        content: 'text message',
+        user: {}
+      };
+
+      const eventRaised = messageHandlerTest(mockMessage);
+      expect(eventRaised).toBeTruthy();
+    });
+
+    it('should not handle incoming message event from non-text channel', () => {
+      const mockMessage = {
+        channel: { type: 'dm' },
+        content: 'text message',
+        user: {}
+      };
+
+      const eventRaised = messageHandlerTest(mockMessage);
+      expect(eventRaised).toBeFalsy();
+    });
+
+    it('should set presence data', () => {
+      const mockPresence = { activity: {} };
+
+      client.setPresence(mockPresence);
+
+      clientUserMock.verify(
+        (u) => u.setPresence(It.isValue(mockPresence)),
+        Times.once()
+      );
+    });
   });
 });

--- a/src/client/discord-client.ts
+++ b/src/client/discord-client.ts
@@ -80,12 +80,19 @@ export class DiscordClient extends EventEmitter implements Client {
       return;
     }
 
-    if (typeof message === 'string' && message.length === 0) {
-      return;
-    }
+    if (typeof message === 'string') {
+      if (message.length === 0) {
+        return;
+      }
 
-    if (typeof message === 'string' && this.lastMessage.author) {
-      message = message.replace(/\{£user\}/g, this.lastMessage.author.username);
+      if (this.lastMessage.author) {
+        message = message.replace(
+          /\{£user\}/g,
+          this.lastMessage.author.username
+        );
+      }
+
+      message = message.replace(/\{£me\}/g, this.client.user.username);
     }
 
     this.lastMessage.channel.send(message);

--- a/src/interfaces/personality.ts
+++ b/src/interfaces/personality.ts
@@ -29,4 +29,12 @@ export interface Personality {
    * @returns (Promise<MessageType>) a promise containing the text or rich embed
    */
   onMessage(message: Message): Promise<MessageType>;
+
+  /**
+   * If this optional method is implemented, it will be called when a user asks
+   * for help with this specific instance
+   *
+   * @param message the raw message object from the server
+   */
+  onHelp?(message: Message): Promise<MessageType>;
 }

--- a/src/personality/simple-interactions.spec.ts
+++ b/src/personality/simple-interactions.spec.ts
@@ -4,7 +4,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { GIT_COMMIT } from '../git-commit';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { ResponseGenerator } from '../interfaces/response-generator';
-import { SimpleInteractions } from './simple-interactions';
+import { helpText, SimpleInteractions } from './simple-interactions';
 
 describe('Simple interactions', () => {
   let mockDeps: DependencyContainer;
@@ -133,6 +133,15 @@ describe('Simple interactions', () => {
       personality.onMessage(message.object).then((response) => {
         expect(response).toContain(GIT_COMMIT.commit);
         expect(response).toContain(GIT_COMMIT.refs);
+        done();
+      });
+    });
+  });
+
+  describe('Help text', () => {
+    it('should respond with help text', (done) => {
+      personality.onHelp().then((response) => {
+        expect(response).toEqual(helpText);
         done();
       });
     });

--- a/src/personality/simple-interactions.ts
+++ b/src/personality/simple-interactions.ts
@@ -5,6 +5,10 @@ import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 import { getValueStartedWith } from '../utils';
 
+export const helpText = `The Simple Interactions plugin provides responses for flipping coins and high fives.
+Using \`{£me} high five\` or \`{£me} ^5\` will give you a virtual high five.
+Using \`{£me} flip a coin\` will flip a virtual coin.`;
+
 export class SimpleInteractions implements Personality {
   constructor(private dependencies: DependencyContainer) {}
 
@@ -32,6 +36,10 @@ export class SimpleInteractions implements Personality {
     }
 
     return Promise.resolve(null);
+  }
+
+  onHelp(): Promise<string> {
+    return Promise.resolve(helpText);
   }
 
   /**


### PR DESCRIPTION
Implement providing help for personality implementations

This is quite a big change, however the gist of it allows for the bot to provide help for features. The help implementation is opt-in and requires adding an implementation for the new optional `onHelp(message)` method outlined in the Personality interface.

To get the bot to provide help, mention it and pass `+help` (future work should allow the prefix to be customised). For each personality implementation that is loaded and provides the `onHelp` signature, the class name will be shown in a help topics list, like so:
```
user > @bot +help

bot > Hi, I'm bot...
      | Help Topics:
      | plugin1
      | plugin2

user > @bot +help plugin1
```

To make responses simpler for personality implementations, the macro `{£me}` can be used in your string responses. This will be expanded to the bot's name.