### PR TITLE
Minecraft server status requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,5 @@ dist
 config.json
 blog-roll.test.json
 blog-roll.json
+mc-servers.json
 src/git-commit.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "discord.js": "12.5.1",
+        "minecraft-server-util": "^3.4.2",
         "node-cleanup": "^2.1.2",
         "node-fetch": "2.6.1",
         "sqlite3": "5.0.0"
@@ -3268,6 +3269,28 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minecraft-server-util": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/minecraft-server-util/-/minecraft-server-util-3.4.2.tgz",
+      "integrity": "sha512-4iErpsCgPzj7SyWWMJiAv6DVWWQ+89sEcKxY1BfArvOzrK/xlnwf6+Ypm7Bp29BV10hTA3UMLq+qBSzCht+fMQ==",
+      "dependencies": {
+        "ansi-styles": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/minecraft-server-util/node_modules/ansi-styles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.1.0.tgz",
+      "integrity": "sha512-osxifZo3ar56+e8tdYreU6p8FZGciBHo5O0JoDAxMUqZuyNUb+yHEwYtJZ+Z32R459jEgtwVf1u8D7qYwU0l6w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/minimatch": {
@@ -7693,6 +7716,21 @@
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
         "mime-db": "1.44.0"
+      }
+    },
+    "minecraft-server-util": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/minecraft-server-util/-/minecraft-server-util-3.4.2.tgz",
+      "integrity": "sha512-4iErpsCgPzj7SyWWMJiAv6DVWWQ+89sEcKxY1BfArvOzrK/xlnwf6+Ypm7Bp29BV10hTA3UMLq+qBSzCht+fMQ==",
+      "requires": {
+        "ansi-styles": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.1.0.tgz",
+          "integrity": "sha512-osxifZo3ar56+e8tdYreU6p8FZGciBHo5O0JoDAxMUqZuyNUb+yHEwYtJZ+Z32R459jEgtwVf1u8D7qYwU0l6w=="
+        }
       }
     },
     "minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Discord chatbot",
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/jbrowneuk/iris-bot#readme",
   "dependencies": {
     "discord.js": "12.5.1",
+    "minecraft-server-util": "^3.4.2",
     "node-cleanup": "^2.1.2",
     "node-fetch": "2.6.1",
     "sqlite3": "5.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import * as nodeCleanup from 'node-cleanup';
+
 import { DiscordClient } from './client/discord-client';
 import { BotEngine } from './engine/bot-engine';
 import { LoggerImpl } from './engine/logger-impl';
@@ -12,10 +14,9 @@ import { CallResponse } from './personality/call-response';
 import { DieRoll } from './personality/die-roll';
 import { FoxBot } from './personality/fox-bot';
 import { HugBot } from './personality/hug-bot';
+import { McServer } from './personality/mc-server';
 import { MoodControl } from './personality/mood-control';
 import { SimpleInteractions } from './personality/simple-interactions';
-
-import * as nodeCleanup from 'node-cleanup';
 
 // Initialise foundation
 const logger = new LoggerImpl();
@@ -59,6 +60,7 @@ engine.addPersonality(new MoodControl(dependencies, moodEngine));
 engine.addPersonality(new SimpleInteractions(dependencies));
 engine.addPersonality(new CallResponse(dependencies));
 engine.addPersonality(new FoxBot(dependencies));
+engine.addPersonality(new McServer(dependencies));
 
 // Start bot
 engine.initialise();

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -1,0 +1,36 @@
+import { McServer } from './mc-server';
+
+describe('Minecraft server utilities', () => {
+  let personality: McServer;
+
+  beforeEach(() => {
+    personality = new McServer();
+  });
+
+  describe('Ambient messages', () => {
+    it('should resolve to null', (done) => {
+      personality.onMessage().then((response) => {
+        expect(response).toBeNull();
+        done();
+      });
+    });
+  });
+
+  describe('Addressed messages', () => {
+    it('should resolve to null', (done) => {
+      personality.onAddressed().then((response) => {
+        expect(response).toBeNull();
+        done();
+      });
+    });
+  });
+
+  describe('Help messages', () => {
+    it('should resolve to null', (done) => {
+      personality.onHelp().then((response) => {
+        expect(response).toBeNull();
+        done();
+      });
+    });
+  });
+});

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -1,13 +1,17 @@
 import { Guild, Message, MessageEmbed } from 'discord.js';
 import { IMock, Mock } from 'typemoq';
 
-import { McServer, ServerInformation, ServerResponse, statusCommand } from './mc-server';
+import { McServer, ServerInformation, ServerResponse, setCommand, statusCommand } from './mc-server';
 
 import util = require('minecraft-server-util');
 
 class TestableMcServer extends McServer {
-  public SetMockServer(discordId: string, info: ServerInformation): void {
+  public setMockServer(discordId: string, info: ServerInformation): void {
     this.servers.set(discordId, info);
+  }
+
+  public getServers(): Map<string, ServerInformation> {
+    return this.servers;
   }
 }
 
@@ -56,7 +60,45 @@ describe('Minecraft server utilities', () => {
     });
 
     it('should return embed with server info if server associated', (done) => {
-      personality.SetMockServer(MOCK_GUILD_ID, MOCK_SERVER_INFO);
+      personality.setMockServer(MOCK_GUILD_ID, MOCK_SERVER_INFO);
+
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => statusCommand);
+      mockMessage.setup((m) => m.guild).returns(() => mockGuild.object);
+
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(MOCK_RUNNING_STATUS)
+      );
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeTruthy();
+        const embed = response as MessageEmbed;
+        expect(embed.title).toBeTruthy();
+        expect(embed.description).toContain('Your server is online');
+        done();
+      });
+    });
+
+    it('should reflect offline status if server offline', (done) => {
+      personality.setMockServer(MOCK_GUILD_ID, MOCK_SERVER_INFO);
+
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => statusCommand);
+      mockMessage.setup((m) => m.guild).returns(() => mockGuild.object);
+
+      spyOn(util, 'status').and.callFake(() => Promise.resolve<any>(null));
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeTruthy();
+        const embed = response as MessageEmbed;
+        expect(embed.title).toBeTruthy();
+        expect(embed.description).toContain('Your server is offline');
+        done();
+      });
+    });
+
+    it('should reflect offline status if server offline', (done) => {
+      personality.setMockServer(MOCK_GUILD_ID, MOCK_SERVER_INFO);
 
       const mockMessage = Mock.ofType<Message>();
       mockMessage.setup((m) => m.content).returns(() => statusCommand);
@@ -71,6 +113,42 @@ describe('Minecraft server utilities', () => {
         const embed = response as MessageEmbed;
         expect(embed.title).toBeTruthy();
         expect(embed.description).toContain('Your server is');
+        done();
+      });
+    });
+  });
+
+  describe(`${setCommand} messages`, () => {
+    it('should return embed with usage instructions if no param provided', (done) => {
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => setCommand);
+      mockMessage.setup((m) => m.guild).returns(() => mockGuild.object);
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeTruthy();
+        const embed = response as MessageEmbed;
+        expect(embed.description).toContain('Usage:');
+        done();
+      });
+    });
+
+    it('should set server url for current guild', (done) => {
+      const mockUrl = 'my-url.is-not-a.real-url';
+
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage
+        .setup((m) => m.content)
+        .returns(() => `${setCommand} ${mockUrl}`);
+      mockMessage.setup((m) => m.guild).returns(() => mockGuild.object);
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeTruthy();
+        const embed = response as MessageEmbed;
+        expect(embed.description).toBe('Saved the server to this Discord.');
+
+        const servers = personality.getServers();
+        expect(servers.has(MOCK_GUILD_ID)).toBeTrue();
+        expect(servers.get(MOCK_GUILD_ID).url).toBe(mockUrl);
         done();
       });
     });

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -1,16 +1,76 @@
-import { McServer } from './mc-server';
+import { Guild, Message, MessageEmbed } from 'discord.js';
+import { IMock, Mock } from 'typemoq';
+
+import { McServer, ServerInformation, ServerResponse, statusCommand } from './mc-server';
+
+import util = require('minecraft-server-util');
+
+class TestableMcServer extends McServer {
+  public SetMockServer(discordId: string, info: ServerInformation): void {
+    this.servers.set(discordId, info);
+  }
+}
+
+const MOCK_GUILD_ID = 'mockguild';
+const MOCK_SERVER_INFO: ServerInformation = {
+  url: 'localhost',
+  channelId: null,
+  lastKnownOnline: false
+};
+
+const MOCK_RUNNING_STATUS: ServerResponse = {
+  version: '1.16.2',
+  onlinePlayers: 1,
+  maxPlayers: 5,
+  samplePlayers: [{ name: 'bob-bobertson' }]
+};
 
 describe('Minecraft server utilities', () => {
-  let personality: McServer;
+  let mockGuild: IMock<Guild>;
+  let personality: TestableMcServer;
 
   beforeEach(() => {
-    personality = new McServer();
+    mockGuild = Mock.ofType<Guild>();
+    mockGuild.setup((m) => m.id).returns(() => MOCK_GUILD_ID);
+
+    personality = new TestableMcServer();
   });
 
-  describe('Ambient messages', () => {
-    it('should resolve to null', (done) => {
-      personality.onMessage().then((response) => {
-        expect(response).toBeNull();
+  describe(`${statusCommand} messages`, () => {
+    it('should return embed with error if no server associated', (done) => {
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => statusCommand);
+      mockMessage.setup((m) => m.guild).returns(() => mockGuild.object);
+
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(MOCK_RUNNING_STATUS)
+      );
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeTruthy();
+        const embed = response as MessageEmbed;
+        expect(embed.title).toBeTruthy();
+        expect(embed.description).toContain('No Minecraft server associated');
+        done();
+      });
+    });
+
+    it('should return embed with server info if server associated', (done) => {
+      personality.SetMockServer(MOCK_GUILD_ID, MOCK_SERVER_INFO);
+
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => statusCommand);
+      mockMessage.setup((m) => m.guild).returns(() => mockGuild.object);
+
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(MOCK_RUNNING_STATUS)
+      );
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeTruthy();
+        const embed = response as MessageEmbed;
+        expect(embed.title).toBeTruthy();
+        expect(embed.description).toContain('Your server is');
         done();
       });
     });

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -1,0 +1,16 @@
+import { Personality } from '../interfaces/personality';
+import { MessageType } from '../types';
+
+export class McServer implements Personality {
+  public onAddressed(): Promise<MessageType> {
+    return Promise.resolve(null);
+  }
+
+  public onMessage(): Promise<MessageType> {
+    return Promise.resolve(null);
+  }
+
+  onHelp(): Promise<MessageType> {
+    return Promise.resolve(null);
+  }
+}

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEmbed } from 'discord.js';
+import { Message, MessageEmbed, TextChannel } from 'discord.js';
 
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
@@ -26,10 +26,13 @@ export interface ServerResponse {
 const embedTitle = 'Server info';
 const embedErrorColor = 0xff8000;
 const embedSuccessColor = 0x0080ff;
+export const noAssociationCopy =
+  'No Minecraft server associated with this Discord';
 
 // Commands
 export const statusCommand = '+MCSTATUS';
 export const setCommand = '+MCSET';
+export const announceCommand = '+MCANNOUNCE';
 
 export class McServer implements Personality {
   protected servers: Map<string, ServerInformation>;
@@ -51,9 +54,7 @@ export class McServer implements Personality {
 
     if (messageText === statusCommand) {
       if (!this.servers.has(discordServerId)) {
-        embed.setDescription(
-          'No Minecraft server associated with this Discord'
-        );
+        embed.setDescription(noAssociationCopy);
         embed.setColor(embedErrorColor);
         return Promise.resolve(embed);
       }
@@ -95,6 +96,25 @@ export class McServer implements Personality {
       embed.addField('Settings', `${name} 🔗 ${serverUrl}`);
 
       // TODO: need to save here if we want to persist
+      return Promise.resolve(embed);
+    }
+
+    if (messageText === announceCommand) {
+      if (!this.servers.has(discordServerId)) {
+        embed.setDescription(noAssociationCopy);
+        embed.setColor(embedErrorColor);
+        return Promise.resolve(embed);
+      }
+
+      const serverInfo = this.servers.get(discordServerId);
+      const textChannel = message.channel as TextChannel;
+      serverInfo.channelId = textChannel.id;
+
+      embed.setColor(embedSuccessColor);
+      embed.setDescription(
+        `Announcing ${serverInfo.url} updates to ${textChannel.name}`
+      );
+
       return Promise.resolve(embed);
     }
 

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -1,16 +1,113 @@
+import { Message, MessageEmbed } from 'discord.js';
+
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
 
+import util = require('minecraft-server-util');
+
+export interface ServerInformation {
+  url: string;
+  channelId: string;
+  lastKnownOnline: boolean;
+}
+
+export interface ServerPlayer {
+  name: string;
+}
+
+export interface ServerResponse {
+  version: string;
+  onlinePlayers: number;
+  maxPlayers: number;
+  samplePlayers: ServerPlayer[];
+}
+
+// Personality constants
+const embedTitle = 'Server info';
+const embedErrorColor = 0xff8000;
+const embedSuccessColor = 0x0080ff;
+
+// Commands
+export const statusCommand = '+MCSTATUS';
+
 export class McServer implements Personality {
+  protected servers: Map<string, ServerInformation>;
+  protected timerInterval: number | NodeJS.Timer;
+
+  constructor() {
+    this.servers = new Map<string, ServerInformation>();
+  }
+
   public onAddressed(): Promise<MessageType> {
     return Promise.resolve(null);
   }
 
-  public onMessage(): Promise<MessageType> {
+  public onMessage(message: Message): Promise<MessageType> {
+    const messageText = message.content.toUpperCase();
+    const discordServerId = message.guild.id;
+    const embed = new MessageEmbed();
+    embed.setTitle(embedTitle);
+
+    if (messageText === statusCommand) {
+      if (!this.servers.has(discordServerId)) {
+        embed.setDescription(
+          'No Minecraft server associated with this Discord'
+        );
+        embed.setColor(embedErrorColor);
+        return Promise.resolve(embed);
+      }
+
+      const minecraftServerUrl = this.servers.get(discordServerId).url;
+      return this.getServerStatus(minecraftServerUrl)
+        .then((response) => {
+          const serverStatus = this.generateServerEmbed(response);
+          return serverStatus;
+        })
+        .catch(() => {
+          const serverStatus = this.generateServerEmbed(null);
+          return serverStatus;
+        });
+    }
+
     return Promise.resolve(null);
   }
 
   onHelp(): Promise<MessageType> {
     return Promise.resolve(null);
+  }
+
+  private getServerStatus(url: string): Promise<ServerResponse> {
+    return util
+      .status(url)
+      .then((response: ServerResponse) => {
+        // Handle Aternos servers
+        if (response.version.match(/\d+\.\d+\.\d+/g) === null) {
+          return null;
+        }
+
+        return response;
+      })
+      .catch(
+        (error: Error): ServerResponse => {
+          console.error('Server unreachable:', error);
+          return null;
+        }
+      );
+  }
+
+  private generateServerEmbed(status: ServerResponse): MessageEmbed {
+    const isOnline = status && status !== null;
+    const embed = new MessageEmbed();
+    embed.setTitle(embedTitle);
+    embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
+    embed.setDescription(`Your server is ${isOnline ? 'online' : 'offline'}`);
+
+    if (isOnline) {
+      const players = status.samplePlayers.map((p) => p.name);
+      const playerCount = `${status.onlinePlayers}/${status.maxPlayers} players`;
+      embed.addField('Status', `${playerCount}:\n${players.join('\n')}`);
+    }
+
+    return embed;
   }
 }


### PR DESCRIPTION
This is a rather big change set.

It adds the following functionality:
- The ability to "link" a Discord server to a Minecraft server using `+mcset <address>`
- The ability to query the "linked" server status using `+mcstatus`
- The ability to make the bot announce status changes (on a periodic timer) with `+mcannounce` in the channel.