### PR TITLE
Fix build on prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "discord.js": "12.5.1",
         "minecraft-server-util": "^3.4.2",
         "node-cleanup": "^2.1.2",
         "node-fetch": "2.6.1",
-        "sqlite3": "5.0.0"
+        "sqlite3": "^5.0.2"
       },
       "devDependencies": {
         "@types/jasmine": "^3.6.4",
@@ -3365,9 +3365,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
-      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
@@ -4610,15 +4610,24 @@
       "dev": true
     },
     "node_modules/sqlite3": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.0.tgz",
-      "integrity": "sha512-rjvqHFUaSGnzxDy2AHCwhHy6Zp6MNJzCPGYju4kD8yi6bze4d1/zMTg6C7JI49b7/EM7jKMTvyfN/4ylBKdwfw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.2.tgz",
+      "integrity": "sha512-1SdTNo+BVU211Xj1csWa8lV6KM0CtucDwRyA0VHl91wEH1Mgh7RxUpI4rVvG7OhHrzCSGaVyW5g8vKvlrk9DJA==",
+      "hasInstallScript": true,
       "dependencies": {
-        "node-addon-api": "2.0.0",
+        "node-addon-api": "^3.0.0",
         "node-pre-gyp": "^0.11.0"
       },
       "optionalDependencies": {
         "node-gyp": "3.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
       }
     },
     "node_modules/sshpk": {
@@ -7793,9 +7802,9 @@
       }
     },
     "node-addon-api": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
-      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "node-cleanup": {
       "version": "2.1.2",
@@ -8791,11 +8800,11 @@
       "dev": true
     },
     "sqlite3": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.0.tgz",
-      "integrity": "sha512-rjvqHFUaSGnzxDy2AHCwhHy6Zp6MNJzCPGYju4kD8yi6bze4d1/zMTg6C7JI49b7/EM7jKMTvyfN/4ylBKdwfw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.2.tgz",
+      "integrity": "sha512-1SdTNo+BVU211Xj1csWa8lV6KM0CtucDwRyA0VHl91wEH1Mgh7RxUpI4rVvG7OhHrzCSGaVyW5g8vKvlrk9DJA==",
       "requires": {
-        "node-addon-api": "2.0.0",
+        "node-addon-api": "^3.0.0",
         "node-gyp": "3.x",
         "node-pre-gyp": "^0.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minecraft-server-util": "^3.4.2",
     "node-cleanup": "^2.1.2",
     "node-fetch": "2.6.1",
-    "sqlite3": "5.0.0"
+    "sqlite3": "^5.0.2"
   },
   "devDependencies": {
     "@types/jasmine": "^3.6.4",

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -5,12 +5,10 @@ import { IMock, It, Mock } from 'typemoq';
 import { Client } from '../interfaces/client';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Logger } from '../interfaces/logger';
-import {
-    announceCommand, McServer, noAssociationCopy, ServerInformation,
-    ServerResponse, setCommand, statusCommand
-} from './mc-server';
+import { announceCommand, McServer, noAssociationCopy, ServerInformation, ServerResponse, setCommand, statusCommand } from './mc-server';
 
 import util = require('minecraft-server-util');
+
 class TestableMcServer extends McServer {
   public setMockServer(discordId: string, info: ServerInformation): void {
     this.servers.set(discordId, info);

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -5,7 +5,8 @@ import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
 
-import util = require('minecraft-server-util');
+// This has to be const util = require as it breaks the build if not
+const util = require('minecraft-server-util');
 
 export interface ServerInformation {
   url: string;
@@ -208,7 +209,8 @@ export class McServer implements Personality {
     embed.setDescription(`Your server is ${isOnline ? 'online' : 'offline'}`);
 
     if (isOnline) {
-      const players = status.samplePlayers.map((p) => p.name);
+      // Sample players is occasionally not populated
+      const players = (status.samplePlayers || []).map((p) => p.name);
       const playerCount = `${status.onlinePlayers}/${status.maxPlayers} players`;
       embed.addField('Status', `${playerCount}:\n${players.join('\n')}`);
     }


### PR DESCRIPTION
- Bump the `sqlite3` dependency to 5.0.2 to remove outdated `node-gyp` usage.
- Revert import to require for the Minecraft status checker.
- Fix an issue where a blank player list could cause the Minecraft status checker to throw.

For some reason this build works on my developer environment but not on production. More investigation is required.