### PR TITLE
Minecraft plugin: refactor server status fetch

### DIFF
--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -324,6 +324,46 @@ describe('Minecraft server utilities', () => {
         done();
       });
     });
+
+    it('should not post status to channel if server is online and status does not change', (done) => {
+      let embed: MessageEmbed;
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(MOCK_RUNNING_STATUS)
+      );
+      mockClient
+        .setup((m) => m.findChannelById(It.isAny()))
+        .returns(() => mockChannel.object);
+      mockChannel.setup((m) => m.send(It.isAny())).callback((e) => (embed = e));
+
+      mockServerInfo.channelId = MOCK_CHANNEL_ID;
+      mockServerInfo.lastKnownOnline = true;
+      personality.setMockServer(MOCK_GUILD_ID, mockServerInfo);
+
+      personality.invokeFetch();
+      setTimeout(() => {
+        expect(embed).toBeFalsy();
+        done();
+      });
+    });
+
+    it('should not post status to channel if server is offline and status does not change', (done) => {
+      let embed: MessageEmbed;
+      spyOn(util, 'status').and.callFake(() => Promise.resolve<any>(null));
+      mockClient
+        .setup((m) => m.findChannelById(It.isAny()))
+        .returns(() => mockChannel.object);
+      mockChannel.setup((m) => m.send(It.isAny())).callback((e) => (embed = e));
+
+      mockServerInfo.channelId = MOCK_CHANNEL_ID;
+      mockServerInfo.lastKnownOnline = false;
+      personality.setMockServer(MOCK_GUILD_ID, mockServerInfo);
+
+      personality.invokeFetch();
+      setTimeout(() => {
+        expect(embed).toBeFalsy();
+        done();
+      });
+    });
   });
 
   describe('persisting settings', () => {

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -5,7 +5,9 @@ import { IMock, It, Mock } from 'typemoq';
 import { Client } from '../interfaces/client';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Logger } from '../interfaces/logger';
-import { announceCommand, McServer, noAssociationCopy, ServerInformation, ServerResponse, setCommand, statusCommand } from './mc-server';
+import {
+    announceCommand, linkServerCopy, McServer, noAssociationCopy, ServerInformation, ServerResponse, setCommand, statusCommand
+} from './mc-server';
 
 import util = require('minecraft-server-util');
 
@@ -188,7 +190,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.description).toBe('Saved the server to this Discord.');
+        expect(embed.description).toBe(linkServerCopy);
 
         const servers = personality.getServers();
         expect(servers.has(MOCK_GUILD_ID)).toBeTrue();
@@ -333,6 +335,8 @@ describe('Minecraft server utilities', () => {
     });
 
     it('should load settings on initialise', () => {
+      const mockUrl = 'mock-url';
+      const mockChannelId = 'mock-id';
       const fakeReadFile = (
         path: string,
         enc: string,
@@ -340,7 +344,10 @@ describe('Minecraft server utilities', () => {
       ) => {
         expect(path).toBeTruthy();
         expect(enc).toBeTruthy();
-        cb(null, `{ "${MOCK_GUILD_ID}": { "url": "no", "channelId": null } }`);
+        cb(
+          null,
+          `{ "${MOCK_GUILD_ID}": { "url": "${mockUrl}", "channelId": "${mockChannelId}" } }`
+        );
       };
 
       spyOn(fs, 'readFile').and.callFake(fakeReadFile as any);
@@ -348,7 +355,11 @@ describe('Minecraft server utilities', () => {
       personality.initialise();
 
       const servers = personality.getServers();
-      expect(servers.get(MOCK_GUILD_ID)).toBeTruthy();
+      const serverInfo = servers.get(MOCK_GUILD_ID);
+      expect(serverInfo).toBeTruthy();
+      expect(serverInfo.url).toBe(mockUrl);
+      expect(serverInfo.channelId).toBe(mockChannelId);
+      expect(serverInfo.lastKnownOnline).toBe(false);
     });
 
     it(`should persist settings on ${setCommand}`, (done) => {
@@ -391,9 +402,12 @@ describe('Minecraft server utilities', () => {
   });
 
   describe('Help messages', () => {
-    it('should resolve to null', (done) => {
+    it('should resolve to embed', (done) => {
       personality.onHelp().then((response) => {
-        expect(response).toBeNull();
+        expect(response).not.toBeNull();
+        const embed = response as MessageEmbed;
+        expect(embed.fields.length).toBe(3);
+
         done();
       });
     });

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -29,11 +29,14 @@ export interface ServerResponse {
 const embedTitle = 'Server info';
 const embedErrorColor = 0xff8000;
 const embedSuccessColor = 0x0080ff;
-export const noAssociationCopy =
-  'No Minecraft server associated with this Discord';
 const updateMinutes = 5;
 const defaultSettingsFile = 'mc-servers.json';
 const settingsFileEnc = 'utf-8';
+
+// Response texts
+export const noAssociationCopy =
+  'No Minecraft server associated with this Discord';
+export const linkServerCopy = 'Linked the server to this Discord.';
 
 // Commands
 export const statusCommand = '+MCSTATUS';
@@ -75,110 +78,145 @@ export class McServer implements Personality {
 
   public onMessage(message: Message): Promise<MessageType> {
     const messageText = message.content.toUpperCase();
-    const discordServerId = message.guild.id;
-    const embed = new MessageEmbed();
-    embed.setTitle(embedTitle);
-
     if (messageText === statusCommand) {
-      if (!this.servers.has(discordServerId)) {
-        embed.setDescription(noAssociationCopy);
-        embed.setColor(embedErrorColor);
-        return Promise.resolve(embed);
-      }
-
-      const minecraftServerUrl = this.servers.get(discordServerId).url;
-      return this.getServerStatus(minecraftServerUrl)
-        .then((response) => {
-          const serverStatus = this.generateServerEmbed(response);
-          return serverStatus;
-        })
-        .catch(() => {
-          const serverStatus = this.generateServerEmbed(null);
-          return serverStatus;
-        });
+      return this.handleStatusCommand(message);
     }
 
     if (messageText.startsWith(setCommand)) {
-      const bits = messageText.split(' ');
-      if (bits.length === 1) {
-        embed.setColor(embedErrorColor);
-        embed.setDescription('Usage: `+mcset my.server.address`');
-        embed.addField(
-          'Description',
-          'Associates a Minecraft server with this Discord server'
-        );
-        return Promise.resolve(embed);
-      }
-
-      const serverUrl = bits[1].toLowerCase();
-      const details: ServerInformation = {
-        url: serverUrl,
-        channelId: null,
-        lastKnownOnline: false
-      };
-      this.servers.set(discordServerId, details);
-      const name = message.guild.name;
-      embed.setColor(embedSuccessColor);
-      embed.setDescription('Saved the server to this Discord.');
-      embed.addField('Settings', `${name} 🔗 ${serverUrl}`);
-
-      this.saveServers();
-      return Promise.resolve(embed);
+      return this.handleSetCommand(message);
     }
 
     if (messageText === announceCommand) {
-      if (!this.servers.has(discordServerId)) {
-        embed.setDescription(noAssociationCopy);
-        embed.setColor(embedErrorColor);
-        return Promise.resolve(embed);
-      }
-
-      const serverInfo = this.servers.get(discordServerId);
-      const textChannel = message.channel as TextChannel;
-      serverInfo.channelId = textChannel.id;
-
-      embed.setColor(embedSuccessColor);
-      embed.setDescription(
-        `Announcing ${serverInfo.url} updates to ${textChannel.name}`
-      );
-
-      this.saveServers();
-      return Promise.resolve(embed);
+      return this.handleAnnounceCommand(message);
     }
 
     return Promise.resolve(null);
   }
 
   public onHelp(): Promise<MessageType> {
-    return Promise.resolve(null);
+    const embed = new MessageEmbed();
+    embed.setColor(embedSuccessColor);
+    embed.setTitle('Minecraft Server Plugin');
+    embed.setDescription(
+      'Allows you to check the status of a Minecraft server.'
+    );
+    embed.addField(
+      `Command: ${setCommand} <url>`,
+      'Associates a Minecraft server with this Discord server.',
+      false
+    );
+    embed.addField(
+      `Command: ${statusCommand} <url>`,
+      'Checks the status of the associated Minecraft server.',
+      false
+    );
+    embed.addField(
+      `Command: ${announceCommand} <url>`,
+      'Makes the bot announce status changes of the associated Minecraft server to this channel.',
+      false
+    );
+
+    return Promise.resolve(embed);
   }
 
   protected fetchStatuses(): void {
-    this.servers.forEach((serverDetails) => {
-      this.getServerStatus(serverDetails.url).then((status) => {
-        const isOnline = status && status !== null;
-        if (serverDetails.lastKnownOnline === isOnline) {
-          return;
-        }
+    this.servers.forEach(this.fetchStatus.bind(this));
+  }
 
-        serverDetails.lastKnownOnline = isOnline;
+  private handleStatusCommand(message: Message): Promise<MessageType> {
+    const embed = new MessageEmbed();
+    embed.setTitle(embedTitle);
 
-        // Control posting to channel
-        if (!serverDetails.channelId) {
-          return;
-        }
+    if (!this.servers.has(message.guild.id)) {
+      embed.setDescription(noAssociationCopy);
+      embed.setColor(embedErrorColor);
+      return Promise.resolve(embed);
+    }
 
-        const channel = this.dependencies.client.findChannelById(
-          serverDetails.channelId
-        ) as TextChannel;
+    const minecraftServerUrl = this.servers.get(message.guild.id).url;
+    return this.getServerStatus(minecraftServerUrl)
+      .then((response) => this.generateServerEmbed(response))
+      .catch(() => this.generateServerEmbed(null));
+  }
 
-        if (!channel || channel === null) {
-          return;
-        }
+  private handleSetCommand(message: Message): Promise<MessageType> {
+    const embed = new MessageEmbed();
+    embed.setTitle(embedTitle);
 
-        const embed = this.generateServerEmbed(status);
-        channel.send(embed);
-      });
+    const bits = message.content.toUpperCase().split(' ');
+    if (bits.length === 1) {
+      embed.setColor(embedErrorColor);
+      embed.setDescription('Usage: `+mcset my.server.address`');
+      embed.addField(
+        'Description',
+        'Associates a Minecraft server with this Discord server'
+      );
+      return Promise.resolve(embed);
+    }
+
+    const serverUrl = bits[1].toLowerCase();
+    const details: ServerInformation = {
+      url: serverUrl,
+      channelId: null,
+      lastKnownOnline: false
+    };
+    this.servers.set(message.guild.id, details);
+    const name = message.guild.name;
+    embed.setColor(embedSuccessColor);
+    embed.setDescription(linkServerCopy);
+    embed.addField('Link information', `${name} 🔗 ${serverUrl}`);
+
+    this.saveServers();
+    return Promise.resolve(embed);
+  }
+
+  private handleAnnounceCommand(message: Message): Promise<MessageType> {
+    const embed = new MessageEmbed();
+    embed.setTitle(embedTitle);
+
+    if (!this.servers.has(message.guild.id)) {
+      embed.setDescription(noAssociationCopy);
+      embed.setColor(embedErrorColor);
+      return Promise.resolve(embed);
+    }
+
+    const serverInfo = this.servers.get(message.guild.id);
+    const textChannel = message.channel as TextChannel;
+    serverInfo.channelId = textChannel.id;
+
+    embed.setColor(embedSuccessColor);
+    embed.setDescription(
+      `Announcing ${serverInfo.url} updates to ${textChannel.name}`
+    );
+
+    this.saveServers();
+    return Promise.resolve(embed);
+  }
+
+  private fetchStatus(serverDetails: ServerInformation): void {
+    this.getServerStatus(serverDetails.url).then((status) => {
+      const isOnline = status !== null;
+      if (serverDetails.lastKnownOnline === isOnline) {
+        return;
+      }
+
+      serverDetails.lastKnownOnline = isOnline;
+
+      // Control posting to channel
+      if (!serverDetails.channelId) {
+        return;
+      }
+
+      const channel = this.dependencies.client.findChannelById(
+        serverDetails.channelId
+      ) as TextChannel;
+
+      if (!channel || channel === null) {
+        return;
+      }
+
+      const embed = this.generateServerEmbed(status);
+      channel.send(embed);
     });
   }
 
@@ -202,17 +240,16 @@ export class McServer implements Personality {
   }
 
   private generateServerEmbed(status: ServerResponse): MessageEmbed {
-    const isOnline = status && status !== null;
+    const isOnline = status !== null;
     const embed = new MessageEmbed();
     embed.setTitle(embedTitle);
     embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
     embed.setDescription(`Your server is ${isOnline ? 'online' : 'offline'}`);
 
-    if (isOnline) {
+    if (isOnline && status.onlinePlayers && status.onlinePlayers > 0) {
       // Sample players is occasionally not populated
       const players = (status.samplePlayers || []).map((p) => p.name);
-      const playerCount = `${status.onlinePlayers}/${status.maxPlayers} players`;
-      embed.addField('Status', `${playerCount}:\n${players.join('\n')}`);
+      embed.addField('Status', `Players online:\n${players.join('\n')}`);
     }
 
     return embed;


### PR DESCRIPTION
There was duplication of the server status fetch code - this changeset refactors to use only a single code path. It also fixes an issue where the online status could be set to an invalid value.

Help text was also added to the plugin.