### PR TITLE
Remove URL from McServer plugin help text

### DIFF
--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -451,5 +451,19 @@ describe('Minecraft server utilities', () => {
         done();
       });
     });
+
+    it('should only contain <url> for set command help', (done) => {
+      personality.onHelp().then((response) => {
+        expect(response).not.toBeNull();
+        const embed = response as MessageEmbed;
+
+        embed.fields.forEach((field) => {
+          const isSetCommand = field.name.includes(setCommand);
+          expect(field.name.includes('<url>')).toBe(isSetCommand);
+        });
+
+        done();
+      });
+    });
   });
 });

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -106,12 +106,12 @@ export class McServer implements Personality {
       false
     );
     embed.addField(
-      `Command: ${statusCommand} <url>`,
+      `Command: ${statusCommand}`,
       'Checks the status of the associated Minecraft server.',
       false
     );
     embed.addField(
-      `Command: ${announceCommand} <url>`,
+      `Command: ${announceCommand}`,
       'Makes the bot announce status changes of the associated Minecraft server to this channel.',
       false
     );


### PR DESCRIPTION
The help text for the McServer erroneously had a URL parameter specified for all the commands. This has been removed.

Fixes #45 