### PR TITLE
Improve handling of initial release servers in MC server status plugin

### DIFF
--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -423,6 +423,30 @@ describe('Minecraft server utilities', () => {
         done();
       });
     });
+
+    it('should extract correct version if server is reporting three part version', (done) => {
+      const semVer = '1.16.2';
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(mapVersion(semVer))
+      );
+
+      personality.invokeGetServerStatus().then((response) => {
+        expect(response.version).toBe(semVer);
+        done();
+      });
+    });
+
+    it('should extract correct version if server is reporting three part version with custom software', (done) => {
+      const semVer = '1.16.2';
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(mapVersion(`Paper ${semVer}`))
+      );
+
+      personality.invokeGetServerStatus().then((response) => {
+        expect(response.version).toBe(semVer);
+        done();
+      });
+    });
   });
 
   describe('persisting settings', () => {

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -27,6 +27,10 @@ class TestableMcServer extends McServer {
   public hasTimer(): boolean {
     return this.timerInterval && this.timerInterval > 0;
   }
+
+  public invokeGetServerStatus() {
+    return this.getServerStatus('localhost');
+  }
 }
 
 const MOCK_GUILD_ID = 'mockguild';
@@ -115,7 +119,7 @@ describe('Minecraft server utilities', () => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
         expect(embed.title).toBeTruthy();
-        expect(embed.description).toContain('Your server is online');
+        expect(embed.description).toContain('online');
         done();
       });
     });
@@ -133,12 +137,12 @@ describe('Minecraft server utilities', () => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
         expect(embed.title).toBeTruthy();
-        expect(embed.description).toContain('Your server is offline');
+        expect(embed.description).toContain('offline');
         done();
       });
     });
 
-    it('should reflect offline status if server offline', (done) => {
+    it('should reflect online status if server offline', (done) => {
       personality.setMockServer(MOCK_GUILD_ID, mockServerInfo);
 
       const mockMessage = Mock.ofType<Message>();
@@ -153,7 +157,7 @@ describe('Minecraft server utilities', () => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
         expect(embed.title).toBeTruthy();
-        expect(embed.description).toContain('Your server is');
+        expect(embed.description).toContain('online');
         done();
       });
     });
@@ -280,7 +284,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('Your server is online');
+        expect(embed.description).toContain('online');
         done();
       });
     });
@@ -300,7 +304,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('Your server is offline');
+        expect(embed.description).toContain('offline');
         done();
       });
     });
@@ -320,7 +324,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('Your server is offline');
+        expect(embed.description).toContain('offline');
         done();
       });
     });
@@ -361,6 +365,61 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeFalsy();
+        done();
+      });
+    });
+  });
+
+  describe('server status handling', () => {
+    function mapVersion(version: string): ServerResponse {
+      return {
+        version,
+        onlinePlayers: 1,
+        maxPlayers: 5,
+        samplePlayers: [{ name: 'bob-bobertson' }]
+      };
+    }
+
+    it('should provide valid status if server is reporting two part version', (done) => {
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(mapVersion('1.17'))
+      );
+
+      personality.invokeGetServerStatus().then((response) => {
+        expect(response).toBeTruthy();
+        done();
+      });
+    });
+
+    it('should provide valid status if server is reporting three part version', (done) => {
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(mapVersion('1.16.5'))
+      );
+
+      personality.invokeGetServerStatus().then((response) => {
+        expect(response).toBeTruthy();
+        done();
+      });
+    });
+
+    it('should provide valid status if server is reporting three part version with custom software', (done) => {
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(mapVersion('Paper 1.16.2'))
+      );
+
+      personality.invokeGetServerStatus().then((response) => {
+        expect(response).toBeTruthy();
+        done();
+      });
+    });
+
+    it('should provide null status if server is reporting Exaroton-style sleeping text', (done) => {
+      spyOn(util, 'status').and.callFake(() =>
+        Promise.resolve<any>(mapVersion('§9◉ Sleeping'))
+      );
+
+      personality.invokeGetServerStatus().then((response) => {
+        expect(response).toBeNull();
         done();
       });
     });

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -232,13 +232,23 @@ export class McServer implements Personality {
     return util
       .status(url)
       .then((response: ServerResponse) => {
-        // Handle Aternos/Exaroton servers
-        const versionRegex = /\b\d+(\.\d+){1,2}\b/;
-        if (response && response.version.match(versionRegex) === null) {
+        if (!response || !response.version) {
           return null;
         }
 
-        return response;
+        // Handle Aternos/Exaroton servers
+        const versionRegex = /\b\d+(\.\d+){1,2}\b/;
+        const matches = response.version.match(versionRegex);
+        if (matches === null || matches.length === 0) {
+          return null;
+        }
+
+        return {
+          version: matches[0],
+          onlinePlayers: response.onlinePlayers,
+          maxPlayers: response.maxPlayers,
+          samplePlayers: response.samplePlayers
+        };
       })
       .catch(
         (error: Error): ServerResponse => {
@@ -253,8 +263,9 @@ export class McServer implements Personality {
     const embed = new MessageEmbed();
     embed.setTitle(embedTitle);
     embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
-    const statusText = `Status: ${isOnline ? 'online' : 'offline'}`;
-    const versionText = status && status.version ? `\nRunning: ${status.version}` : '';
+    const statusText = `Status: **${isOnline ? 'online' : 'offline'}**`;
+    const versionText =
+      status && status.version ? `\nRunning: **${status.version}**` : '';
     embed.setDescription(`${statusText}${versionText}`);
 
     if (isOnline && status.onlinePlayers && status.onlinePlayers > 0) {

--- a/src/personality/mc-server.ts
+++ b/src/personality/mc-server.ts
@@ -228,12 +228,13 @@ export class McServer implements Personality {
     });
   }
 
-  private getServerStatus(url: string): Promise<ServerResponse> {
+  protected getServerStatus(url: string): Promise<ServerResponse> {
     return util
       .status(url)
       .then((response: ServerResponse) => {
-        // Handle Aternos servers
-        if (response && response.version.match(/\d+\.\d+\.\d+/g) === null) {
+        // Handle Aternos/Exaroton servers
+        const versionRegex = /\b\d+(\.\d+){1,2}\b/;
+        if (response && response.version.match(versionRegex) === null) {
           return null;
         }
 
@@ -252,7 +253,9 @@ export class McServer implements Personality {
     const embed = new MessageEmbed();
     embed.setTitle(embedTitle);
     embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
-    embed.setDescription(`Your server is ${isOnline ? 'online' : 'offline'}`);
+    const statusText = `Status: ${isOnline ? 'online' : 'offline'}`;
+    const versionText = status && status.version ? `\nRunning: ${status.version}` : '';
+    embed.setDescription(`${statusText}${versionText}`);
 
     if (isOnline && status.onlinePlayers && status.onlinePlayers > 0) {
       // Sample players is occasionally not populated


### PR DESCRIPTION
Initial release versions of Minecraft omit the patch version `.0` from the server version string. This means that a server running the "caves and cliffs" update released on 8th June reports its server version as `1.17`.

Unfortunately, the plugin expects a more strict adherence to semver - it expects to see `1.17.0`. Since `1.17` was returned, the plugin assumed the version number to be invalid and that the server was offline as opposed to online.

This change set improves the recognition of version numbers and also adds it to the bot response.