### PR TITLE
Improve Minecraft Server Status plugin message formatting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 0.1.8 changes:
+d799316e050ad8c572901e24925d0cec95ad320b Refactor MCServer plugin embeds into separate file
+f140f3f57c545a294f1acf740b942018bf3c8074 Reorganise server status embed to display information more naturally
+
 Release 0.1.7 changes:
 054e2cda02f1cccedefa77654e3c53cb9c6432fb Implement cat picture API route
 15b54a5796f4b767444075bda9aec1b615116143 Bump dependencies with security vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "iris-bot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "discord.js": "12.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Discord chatbot",
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",

--- a/src/personality/constants/mc-server.ts
+++ b/src/personality/constants/mc-server.ts
@@ -1,0 +1,4 @@
+// Commands
+export const statusCommand = '+MCSTATUS';
+export const setCommand = '+MCSET';
+export const announceCommand = '+MCANNOUNCE';

--- a/src/personality/embeds/mc-server.spec.ts
+++ b/src/personality/embeds/mc-server.spec.ts
@@ -1,0 +1,90 @@
+import { announceCommand, setCommand, statusCommand } from '../constants/mc-server';
+import * as embeds from './mc-server';
+
+describe('Embed formatting for Minecraft server utilities', () => {
+  describe('generateHelpEmbed', () => {
+    it('should contain help text for commands', () => {
+      const embed = embeds.generateHelpEmbed();
+      expect(embed.fields.length).toBe(3);
+
+      const setField = embed.fields.find((e) => e.name.includes(setCommand));
+      expect(setField).toBeTruthy();
+      expect(setField.value.length).toBeGreaterThan(0);
+
+      const statusField = embed.fields.find((e) =>
+        e.name.includes(statusCommand)
+      );
+      expect(statusField).toBeTruthy();
+      expect(statusField.value.length).toBeGreaterThan(0);
+
+      const announceField = embed.fields.find((e) =>
+        e.name.includes(announceCommand)
+      );
+      expect(announceField).toBeTruthy();
+      expect(announceField.value.length).toBeGreaterThan(0);
+    });
+
+    it('should only contain <url> for set command help', () => {
+      const embed = embeds.generateHelpEmbed();
+
+      embed.fields.forEach((field) => {
+        const isSetCommand = field.name.includes(setCommand);
+        expect(field.name.includes('<url>')).toBe(isSetCommand);
+      });
+    });
+  });
+
+  describe('generateSetFailureEmbed', () => {
+    it('should contain no association copy as description', () => {
+      const embed = embeds.generateSetFailureEmbed();
+      expect(embed.description).toBe(embeds.noAssociationCopy);
+    });
+  });
+
+  describe('generateSetSuccessEmbed', () => {
+    const linkInfoTitle = 'Link information';
+
+    it('should contain guild name in link information field', () => {
+      const guildName = 'guild-name-here';
+      const embed = embeds.generateSetSuccessEmbed(guildName, '');
+      const field = embed.fields.find((e) => e.name === linkInfoTitle);
+      expect(field.value).toContain(guildName);
+    });
+
+    it('should contain server url in link information field', () => {
+      const serverUrl = 'server.host';
+      const embed = embeds.generateSetSuccessEmbed('', serverUrl);
+      const field = embed.fields.find((e) => e.name === linkInfoTitle);
+      expect(field.value).toContain(serverUrl);
+    });
+  });
+
+  describe('generateSetFailureEmbed', () => {
+    it('should contain usage text', () => {
+      const embed = embeds.generateSetFailureEmbed();
+      expect(embed.description).toContain(`${setCommand} my.server.address`);
+      expect(embed.fields[0]).toBeTruthy();
+    });
+  });
+
+  describe('generateAnnounceNoAssociationEmbed', () => {
+    it('should contain no association copy', () => {
+      const embed = embeds.generateAnnounceNoAssociationEmbed();
+      expect(embed.description).toBe(embeds.noAssociationCopy);
+    });
+  });
+
+  describe('generateAnnounceSuccessEmbed', () => {
+    it('should contain channel name', () => {
+      const channelName = 'guild-name-here';
+      const embed = embeds.generateAnnounceSuccessEmbed('', channelName);
+      expect(embed.description).toContain(channelName);
+    });
+
+    it('should contain server url', () => {
+      const serverUrl = 'server.host';
+      const embed = embeds.generateAnnounceSuccessEmbed(serverUrl, '');
+      expect(embed.description).toContain(serverUrl);
+    });
+  });
+});

--- a/src/personality/embeds/mc-server.ts
+++ b/src/personality/embeds/mc-server.ts
@@ -1,0 +1,144 @@
+import { MessageEmbed } from 'discord.js';
+
+import { announceCommand, setCommand, statusCommand } from '../constants/mc-server';
+import { ServerResponse } from '../interfaces/mc-server';
+
+const embedTitle = 'Server info';
+const embedErrorColor = 0xff8000;
+const embedSuccessColor = 0x0080ff;
+
+// Response texts
+export const noAssociationCopy =
+  'No Minecraft server associated with this Discord';
+export const linkServerCopy = 'Linked the server to this Discord.';
+
+/**
+ * Generates a message embed containing the help for the plugin
+ *
+ * @returns a MessageEmbed containing help text
+ */
+export function generateHelpEmbed(): MessageEmbed {
+  const embed = new MessageEmbed();
+  embed.setColor(embedSuccessColor);
+  embed.setTitle('Minecraft Server Plugin');
+  embed.setDescription('Allows you to check the status of a Minecraft server.');
+  embed.addField(
+    `Command: ${setCommand} <url>`,
+    'Associates a Minecraft server with this Discord server.',
+    false
+  );
+  embed.addField(
+    `Command: ${statusCommand}`,
+    'Checks the status of the associated Minecraft server.',
+    false
+  );
+  embed.addField(
+    `Command: ${announceCommand}`,
+    'Makes the bot announce status changes of the associated Minecraft server to this channel.',
+    false
+  );
+
+  return embed;
+}
+
+/**
+ * Generates a message embed containing a summary of the server's status
+ *
+ * @param url the server url
+ * @param status the updated server status
+ * @returns a MessageEmbed containing a summary of the server status
+ */
+export function generateServerEmbed(
+  url: string,
+  status: ServerResponse
+): MessageEmbed {
+  const isOnline = status !== null;
+
+  const embed = new MessageEmbed();
+  embed.setTitle(`Server: ${url}`);
+  embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
+
+  const statusText = `Status: **${isOnline ? 'online' : 'offline'}**`;
+  const versionText =
+    status && status.version ? `\nRunning: **${status.version}**` : '';
+  embed.setDescription(`${statusText}${versionText}`);
+
+  if (isOnline && status.onlinePlayers && status.onlinePlayers > 0) {
+    // Sample players is occasionally not populated
+    const players = (status.samplePlayers || []).map((p) => p.name);
+    embed.addField(`Players (${status.onlinePlayers})`, players.join('\n'));
+  }
+
+  return embed;
+}
+
+/**
+ * Generates a message embed containing a message that a server has not been
+ * linked to a discord guild
+ *
+ * @returns a MessageEmbed containing an error
+ */
+export function generateStatusFailureEmbed(): MessageEmbed {
+  const embed = new MessageEmbed();
+  embed.setTitle(embedTitle);
+  embed.setDescription(noAssociationCopy);
+  embed.setColor(embedErrorColor);
+  return embed;
+}
+
+/**
+ * Generates a message embed containing a message summarising a successful link
+ * of a server to a discord guild
+ *
+ * @returns a MessageEmbed containing a summary of the link
+ */
+export function generateSetSuccessEmbed(
+  guildName: string,
+  serverUrl: string
+): MessageEmbed {
+  const embed = new MessageEmbed();
+  embed.setTitle(embedTitle);
+  embed.setColor(embedSuccessColor);
+  embed.setDescription(linkServerCopy);
+  embed.addField('Link information', `${guildName} 🔗 ${serverUrl}`);
+  return embed;
+}
+
+/**
+ * Generates a message embed containing a message that a server has not been
+ * linked to a discord guild
+ *
+ * @returns a MessageEmbed containing an error
+ */
+export function generateSetFailureEmbed(): MessageEmbed {
+  const embed = new MessageEmbed();
+  embed.setTitle(embedTitle);
+
+  embed.setColor(embedErrorColor);
+  embed.setDescription(`Usage: \`${setCommand} my.server.address\``);
+  embed.addField(
+    'Description',
+    'Associates a Minecraft server with this Discord server'
+  );
+
+  return embed;
+}
+
+export function generateAnnounceNoAssociationEmbed(): MessageEmbed {
+  const embed = new MessageEmbed();
+  embed.setTitle(embedTitle);
+  embed.setDescription(noAssociationCopy);
+  embed.setColor(embedErrorColor);
+  return embed;
+}
+
+export function generateAnnounceSuccessEmbed(
+  serverUrl: string,
+  channelName: string
+): MessageEmbed {
+  const embed = new MessageEmbed();
+  embed.setTitle(embedTitle);
+  embed.setColor(embedSuccessColor);
+  embed.setDescription(`Announcing ${serverUrl} updates to ${channelName}`);
+  return embed;
+}

--- a/src/personality/embeds/mc-server.ts
+++ b/src/personality/embeds/mc-server.ts
@@ -55,13 +55,14 @@ export function generateServerEmbed(
   const isOnline = status !== null;
 
   const embed = new MessageEmbed();
-  embed.setTitle(`Server: ${url}`);
-  embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
+  const statusText = isOnline ? 'online' : 'offline';
 
-  const statusText = `Status: **${isOnline ? 'online' : 'offline'}**`;
+  embed.setTitle(`Server ${statusText}`);
+  embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
+  const urlText = `Address: **${url}**`;
   const versionText =
     status && status.version ? `\nRunning: **${status.version}**` : '';
-  embed.setDescription(`${statusText}${versionText}`);
+  embed.setDescription(`${urlText}${versionText}`);
 
   if (isOnline && status.onlinePlayers && status.onlinePlayers > 0) {
     // Sample players is occasionally not populated

--- a/src/personality/interfaces/mc-server.ts
+++ b/src/personality/interfaces/mc-server.ts
@@ -1,0 +1,16 @@
+export interface ServerInformation {
+  url: string;
+  channelId: string;
+  lastKnownOnline: boolean;
+}
+
+export interface ServerPlayer {
+  name: string;
+}
+
+export interface ServerResponse {
+  version: string;
+  onlinePlayers: number;
+  maxPlayers: number;
+  samplePlayers: ServerPlayer[];
+}

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -5,9 +5,10 @@ import { IMock, It, Mock } from 'typemoq';
 import { Client } from '../interfaces/client';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Logger } from '../interfaces/logger';
-import {
-    announceCommand, linkServerCopy, McServer, noAssociationCopy, ServerInformation, ServerResponse, setCommand, statusCommand
-} from './mc-server';
+import { announceCommand, setCommand, statusCommand } from './constants/mc-server';
+import { noAssociationCopy } from './embeds/mc-server';
+import { ServerInformation, ServerResponse } from './interfaces/mc-server';
+import { McServer } from './mc-server';
 
 import util = require('minecraft-server-util');
 
@@ -35,6 +36,7 @@ class TestableMcServer extends McServer {
 
 const MOCK_GUILD_ID = 'mockguild';
 const MOCK_CHANNEL_ID = 'mockchannel';
+const MOCK_GUILD_NAME = 'mock name';
 const MOCK_CHANNEL_NAME = 'mock channel name';
 
 const MOCK_RUNNING_STATUS: ServerResponse = {
@@ -55,6 +57,7 @@ describe('Minecraft server utilities', () => {
   beforeEach(() => {
     mockGuild = Mock.ofType<Guild>();
     mockGuild.setup((m) => m.id).returns(() => MOCK_GUILD_ID);
+    mockGuild.setup((m) => m.name).returns(() => MOCK_GUILD_NAME);
 
     mockChannel = Mock.ofType<TextChannel>();
     mockChannel.setup((m) => m.id).returns(() => MOCK_CHANNEL_ID);
@@ -194,7 +197,8 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.description).toBe(linkServerCopy);
+        expect(embed.fields[0].value).toContain(mockUrl);
+        expect(embed.fields[0].value).toContain(MOCK_GUILD_NAME);
 
         const servers = personality.getServers();
         expect(servers.has(MOCK_GUILD_ID)).toBeTrue();
@@ -528,23 +532,6 @@ describe('Minecraft server utilities', () => {
     it('should resolve to embed', (done) => {
       personality.onHelp().then((response) => {
         expect(response).not.toBeNull();
-        const embed = response as MessageEmbed;
-        expect(embed.fields.length).toBe(3);
-
-        done();
-      });
-    });
-
-    it('should only contain <url> for set command help', (done) => {
-      personality.onHelp().then((response) => {
-        expect(response).not.toBeNull();
-        const embed = response as MessageEmbed;
-
-        embed.fields.forEach((field) => {
-          const isSetCommand = field.name.includes(setCommand);
-          expect(field.name.includes('<url>')).toBe(isSetCommand);
-        });
-
         done();
       });
     });

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -121,8 +121,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.title).toBeTruthy();
-        expect(embed.description).toContain('online');
+        expect(embed.title).toContain('online');
         done();
       });
     });
@@ -139,8 +138,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.title).toBeTruthy();
-        expect(embed.description).toContain('offline');
+        expect(embed.title).toContain('offline');
         done();
       });
     });
@@ -159,8 +157,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.title).toBeTruthy();
-        expect(embed.description).toContain('online');
+        expect(embed.title).toContain('online');
         done();
       });
     });
@@ -288,7 +285,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('online');
+        expect(embed.title).toContain('online');
         done();
       });
     });
@@ -308,7 +305,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('offline');
+        expect(embed.title).toContain('offline');
         done();
       });
     });
@@ -328,7 +325,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('offline');
+        expect(embed.title).toContain('offline');
         done();
       });
     });


### PR DESCRIPTION
This set of changes moves the most important items to the top of a message embed: the server status text and URL. It also removes the redundant embed titles.

Online message format:
> ## Server online
> Address: **url**
> Running: **version**
> ### Players (2)
> Player1
> Player2

Offline message format:
> ## Server offline
> Address: **url**