### PR TITLE
Implement basic sticker image personality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { HugBot } from './personality/hug-bot';
 import { McServer } from './personality/mc-server';
 import { MoodControl } from './personality/mood-control';
 import { SimpleInteractions } from './personality/simple-interactions';
+import { Stickers } from './personality/stickers';
 
 // Initialise foundation
 const logger = new LoggerImpl();
@@ -65,6 +66,7 @@ engine.addPersonality(new HugBot());
 engine.addPersonality(new McServer(dependencies));
 engine.addPersonality(new MoodControl(dependencies, moodEngine));
 engine.addPersonality(new SimpleInteractions(dependencies));
+engine.addPersonality(new Stickers(dependencies));
 
 // Start bot
 engine.initialise();

--- a/src/personality/stickers.spec.ts
+++ b/src/personality/stickers.spec.ts
@@ -1,0 +1,90 @@
+import { Message, MessageEmbed } from 'discord.js';
+import * as nodeFetch from 'node-fetch';
+import { Mock } from 'typemoq';
+
+import { DependencyContainer } from '../interfaces/dependency-container';
+import { Logger } from '../interfaces/logger';
+import { helpText, prefix, Stickers } from './stickers';
+
+describe('Improved Discord stickers', () => {
+  let fetchSpy: jasmine.Spy;
+  let personality: Stickers;
+
+  beforeEach(() => {
+    const mockLogger = Mock.ofType<Logger>();
+    const mockDependencies = Mock.ofType<DependencyContainer>();
+    mockDependencies.setup((s) => s.logger).returns(() => mockLogger.object);
+    personality = new Stickers(mockDependencies.object);
+  });
+
+  it('should not respond to addressed messages', (done) => {
+    personality.onAddressed().then((response) => {
+      expect(response).toBeNull();
+      done();
+    });
+  });
+
+  describe('Sticker command', () => {
+    beforeEach(() => {
+      fetchSpy = spyOn(nodeFetch, 'default');
+    });
+
+    it('should request sticker on command and post if found', (done) => {
+      const mockSticker = 'http://localhost/sticker';
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => `${prefix}sticker`);
+
+      const mockFetchResponse = {
+        ok: true,
+        json: () => Promise.resolve({ url: mockSticker })
+      };
+      fetchSpy.and.returnValue(Promise.resolve(mockFetchResponse));
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(fetchSpy).toHaveBeenCalled();
+        expect(response).toBe(mockSticker);
+        done();
+      });
+    });
+
+    it('should request sticker on command and respond if not found', (done) => {
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => `${prefix}sticker`);
+
+      fetchSpy.and.returnValue(Promise.reject('A rejection'));
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(fetchSpy).toHaveBeenCalled();
+        expect(response).toContain('Cannot find');
+        done();
+      });
+    });
+
+    it('should request sticker on command and respond if invalid data', (done) => {
+      const mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((m) => m.content).returns(() => `${prefix}sticker`);
+
+      const mockFetchResponse = {
+        ok: true,
+        json: () => Promise.resolve('text value')
+      };
+      fetchSpy.and.returnValue(Promise.resolve(mockFetchResponse));
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(fetchSpy).toHaveBeenCalled();
+        expect(response).toContain('Cannot find');
+        done();
+      });
+    });
+  });
+
+  describe('Help functionality', () => {
+    it('should return embed with help text', (done) => {
+      personality.onHelp().then((response) => {
+        const embed = response as MessageEmbed;
+        expect(embed.description).toBe(helpText);
+        done();
+      });
+    });
+  });
+});

--- a/src/personality/stickers.ts
+++ b/src/personality/stickers.ts
@@ -1,0 +1,67 @@
+import { Message, MessageEmbed } from 'discord.js';
+import * as nodeFetch from 'node-fetch';
+
+import { DependencyContainer } from '../interfaces/dependency-container';
+import { Personality } from '../interfaces/personality';
+import { MessageType } from '../types';
+
+const apiBase = 'https://media.jbrowne.io/stickers/';
+const apiUrl = `${apiBase}stickers.php?name=`;
+
+export const prefix = '+s ';
+export const helpText = `Posts a large sticker image to chat. All image names can be found at ${apiBase}`;
+
+interface Sticker {
+  name: string;
+  url: string;
+}
+
+export class Stickers implements Personality {
+  constructor(private dependencies: DependencyContainer) {}
+
+  onAddressed(): Promise<MessageType> {
+    return Promise.resolve(null);
+  }
+
+  onMessage(message: Message): Promise<MessageType> {
+    if (message.content.indexOf(prefix) !== 0) {
+      return Promise.resolve(null);
+    }
+
+    const stickerName = message.content.substring(prefix.length).trim();
+    return this.fetchSticker(stickerName);
+  }
+
+  onHelp(): Promise<MessageType> {
+    const embed = new MessageEmbed();
+    embed.setTitle('Stickers (large emotes) plugin');
+    embed.setDescription(helpText);
+
+    embed.addField('Commands', `\`${prefix}<sticker name>\``);
+
+    embed.addField('Example', `\`${prefix}hug\``);
+
+    return Promise.resolve(embed);
+  }
+
+  private fetchSticker(stickerName: string): Promise<string> {
+    return nodeFetch
+      .default(apiUrl + stickerName)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Unable to fetch API');
+        }
+
+        return response.json();
+      })
+      .then((rawData) => this.handleStickerResponse(rawData))
+      .catch((e) => {
+        this.dependencies.logger.error(e);
+        return 'Cannot find that sticker';
+      });
+  }
+
+  private handleStickerResponse(response: Sticker): string {
+    return response.url || 'Cannot find that sticker';
+  }
+}


### PR DESCRIPTION
This change set implements a bot personality that can fetch named images from a backend with the `+s` command. It is inspired by discussions on the Domain of J Discord server about having larger emotes. The feature is named "stickers" after recent additions to Discord.

On using the command, the bot requests the named sticker from the API. The API response with sticker data or 404 depending on whether a sticker is found.

Sticker data is a JSON object with a `url` string field, which can link to any image Discord can display. In the reference API it also has an `attribution` field to put image credits, which may be adopted by the bot moving forwards.