### PR TITLE
Hangman game statistics and persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "iris-bot",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "discord.js": "12.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Discord chatbot",
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",

--- a/src/personality/basic-intelligence.spec.ts
+++ b/src/personality/basic-intelligence.spec.ts
@@ -1,5 +1,6 @@
 import { Message } from 'discord.js';
 import { Mock } from 'typemoq';
+
 import { BasicIntelligence } from './basic-intelligence';
 
 describe('basic intelligence', () => {
@@ -8,7 +9,7 @@ describe('basic intelligence', () => {
     message.setup((m) => m.content).returns(() => 'anything');
     const core = new BasicIntelligence();
 
-    core.onAddressed(message.object, 'anything').then((result: string) => {
+    core.onAddressed(message.object, 'anything').then((result) => {
       expect(result).toBe(null);
       done();
     });
@@ -19,7 +20,7 @@ describe('basic intelligence', () => {
     message.setup((m) => m.content).returns(() => '+echo');
     const core = new BasicIntelligence();
 
-    core.onMessage(message.object).then((result: string) => {
+    core.onMessage(message.object).then((result) => {
       expect(result).toBe('Echo!');
       done();
     });

--- a/src/personality/constants/hangman-game.ts
+++ b/src/personality/constants/hangman-game.ts
@@ -2,4 +2,5 @@ export const apiUrl = 'https://jbrowne.io/api/words/';
 export const prefix = '+HM';
 export const startCommand = 'START';
 export const guessCommand = 'GUESS';
+export const statsCommand = 'STATS';
 export const blankDisplayChar = '-';

--- a/src/personality/embeds/hangman-game.spec.ts
+++ b/src/personality/embeds/hangman-game.spec.ts
@@ -1,6 +1,6 @@
 import { guessCommand, prefix, startCommand } from '../constants/hangman-game';
-import { GameState } from '../interfaces/hangman-game';
-import { generateGameEmbed, generateHelpEmbed } from './hangman-game';
+import { GameData, GameState, GameStatistics } from '../interfaces/hangman-game';
+import { generateGameEmbed, generateHelpEmbed, generateStatsEmbed } from './hangman-game';
 
 describe('Hangman Game Status embed', () => {
   const mockGame: GameState = {
@@ -22,32 +22,38 @@ describe('Hangman Game Status embed', () => {
   };
 
   it('should display current guessed letters', () => {
-    const embed = generateGameEmbed(mockGame);
+    const gameData: GameData = { state: mockGame, statistics: null };
+    const embed = generateGameEmbed(gameData);
     expect(embed.description).toContain(mockGame.currentDisplay);
   });
 
   it('should display remaining lives', () => {
-    const embed = generateGameEmbed(mockGame);
+    const gameData: GameData = { state: mockGame, statistics: null };
+    const embed = generateGameEmbed(gameData);
     expect(embed.description).toContain(`${mockGame.livesRemaining} chances`);
   });
 
   it('should display incorrect letters if present', () => {
-    const guessSummary = generateGameEmbed(mockGame).fields[0];
+    const gameData: GameData = { state: mockGame, statistics: null };
+    const guessSummary = generateGameEmbed(gameData).fields[0];
     expect(guessSummary.value).toContain(`${mockGame.wrongLetters.join()}`);
   });
 
   it('should display incorrect words if present', () => {
-    const guessSummary = generateGameEmbed(mockGame).fields[0];
+    const gameData: GameData = { state: mockGame, statistics: null };
+    const guessSummary = generateGameEmbed(gameData).fields[0];
     expect(guessSummary.value).toContain(`${mockGame.wrongWords.join()}`);
   });
 
   it('should display none for incorrect letters if not present', () => {
-    const guessSummary = generateGameEmbed(mockNew).fields[0];
+    const gameData: GameData = { state: mockNew, statistics: null };
+    const guessSummary = generateGameEmbed(gameData).fields[0];
     expect(guessSummary.value).toContain('Letters: *none*');
   });
 
   it('should display none for incorrect words if not present', () => {
-    const guessSummary = generateGameEmbed(mockNew).fields[0];
+    const gameData: GameData = { state: mockNew, statistics: null };
+    const guessSummary = generateGameEmbed(gameData).fields[0];
     expect(guessSummary.value).toContain('Words: *none*');
   });
 });
@@ -81,5 +87,42 @@ describe('Hangman Game Help embed', () => {
 
     expect(summaryField).toBeDefined();
     expect(summaryField.value).toContain(guessCommand);
+  });
+});
+
+describe('Hangman Game Summary embed', () => {
+  const statistics: GameStatistics = {
+    totalWins: 5,
+    totalLosses: 2,
+    currentStreak: 3
+  };
+
+  const mockGameData: GameData = { state: null, statistics };
+
+  it('should display total wins', () => {
+    const embed = generateStatsEmbed(mockGameData);
+    const winField = embed.fields.find((f) =>
+      f.name.toUpperCase().includes('WINS')
+    );
+
+    expect(winField.value).toBe('' + statistics.totalWins);
+  });
+
+  it('should display total wins', () => {
+    const embed = generateStatsEmbed(mockGameData);
+    const lossField = embed.fields.find((f) =>
+      f.name.toUpperCase().includes('LOSSES')
+    );
+
+    expect(lossField.value).toBe('' + statistics.totalLosses);
+  });
+
+  it('should display current win streak', () => {
+    const embed = generateStatsEmbed(mockGameData);
+    const streakField = embed.fields.find((f) =>
+      f.name.toUpperCase().includes('STREAK')
+    );
+
+    expect(streakField.value).toBe('' + statistics.currentStreak);
   });
 });

--- a/src/personality/embeds/hangman-game.ts
+++ b/src/personality/embeds/hangman-game.ts
@@ -1,7 +1,7 @@
 import { MessageEmbed } from 'discord.js';
 
 import { guessCommand, prefix, startCommand } from '../constants/hangman-game';
-import { GameState } from '../interfaces/hangman-game';
+import { GameData } from '../interfaces/hangman-game';
 
 const embedTitle = 'Hangman';
 
@@ -30,7 +30,8 @@ export function generateHelpEmbed(): MessageEmbed {
   return embed;
 }
 
-export function generateGameEmbed(gameState: GameState): MessageEmbed {
+export function generateGameEmbed(gameData: GameData): MessageEmbed {
+  const gameState = gameData.state;
   const embed = generateBaseEmbed();
   const letterDisplay = `\`${gameState.currentDisplay}\``;
   const countDisplay = `(${gameState.currentDisplay.length} letters)`;
@@ -48,6 +49,18 @@ export function generateGameEmbed(gameState: GameState): MessageEmbed {
     'Wrong guesses',
     `Letters: ${lettersSummary}\nWords: ${wordsSummary}`
   );
+
+  return embed;
+}
+
+export function generateStatsEmbed(gameData: GameData): MessageEmbed {
+  const stats = gameData.statistics;
+  const embed = generateBaseEmbed();
+  embed.setDescription('Statistics for this Discord server');
+
+  embed.addField('Current win streak', stats.currentStreak);
+  embed.addField('Total wins', stats.totalWins);
+  embed.addField('Total losses', stats.totalLosses);
 
   return embed;
 }

--- a/src/personality/hangman-game.spec.ts
+++ b/src/personality/hangman-game.spec.ts
@@ -1,18 +1,39 @@
-import { Guild, Message } from 'discord.js';
+import { Guild, Message, MessageEmbed } from 'discord.js';
 import * as nodeFetch from 'node-fetch';
 import { IMock, Mock } from 'typemoq';
 
-import { apiUrl, guessCommand, prefix, startCommand } from './constants/hangman-game';
+import { DependencyContainer } from '../interfaces/dependency-container';
+import { apiUrl, guessCommand, prefix, startCommand, statsCommand } from './constants/hangman-game';
 import { HangmanGame } from './hangman-game';
-import { GameState } from './interfaces/hangman-game';
+import { GameData, GameState, GameStatistics } from './interfaces/hangman-game';
 
 class TestableHangmanGame extends HangmanGame {
-  public get gameStateMap(): Map<string, GameState> {
-    return this.gameStates;
+  public constructor() {
+    const mockDeps = Mock.ofType<DependencyContainer>();
+    mockDeps.setup((m) => m.logger).returns(() => console);
+
+    super(mockDeps.object);
+
+    // Lazy init
+    if (!this.gameData) {
+      this.gameData = new Map<string, GameData>();
+    }
   }
 
-  public addMockGameState(id: string): void {
-    const mockState: GameState = {
+  public get gameDataMap(): Map<string, GameData> {
+    return this.gameData;
+  }
+
+  public getStateForGuild(id: string): GameState {
+    return this.gameData.get(id).state;
+  }
+
+  public getStatsForGuild(id: string): GameStatistics {
+    return this.gameData.get(id).statistics;
+  }
+
+  public addMockGameState(id: string): GameData {
+    const state: GameState = {
       timeStarted: 123456,
       currentWord: 'BAFFLE',
       currentDisplay: 'BA--L-',
@@ -20,22 +41,60 @@ class TestableHangmanGame extends HangmanGame {
       wrongLetters: ['C', 'H'],
       wrongWords: ['BATTLE']
     };
-    this.gameStates.set(id, mockState);
+
+    const statistics: GameStatistics = {
+      totalWins: 10,
+      totalLosses: 10,
+      currentStreak: 5
+    };
+
+    const addition = { state, statistics };
+    this.gameData.set(id, addition);
+    return addition;
+  }
+
+  public addBlankGameState(id: string): GameData {
+    const state: GameState = {
+      timeStarted: 0,
+      currentWord: '',
+      currentDisplay: '',
+      livesRemaining: 10,
+      wrongLetters: [],
+      wrongWords: []
+    };
+
+    const statistics: GameStatistics = {
+      totalWins: 0,
+      totalLosses: 0,
+      currentStreak: 0
+    };
+
+    const addition = { state, statistics };
+    this.gameData.set(id, addition);
+    return addition;
+  }
+
+  public setGameCompleteByWin(id: string): void {
+    const game = this.gameData.get(id).state;
+    game.currentDisplay = game.currentWord;
   }
 }
 
 const mockGuildId = 'ABC123';
 
 describe('Hangman game', () => {
+  const mockWord = { word: 'ambivalence' };
+
   let fetchSpy: jasmine.Spy;
   let personality: TestableHangmanGame;
   let mockGuild: IMock<Guild>;
+  let mockMessage: IMock<Message>;
 
   beforeEach(() => {
     mockGuild = Mock.ofType<Guild>();
     mockGuild.setup((m) => m.id).returns(() => mockGuildId);
 
-    personality = new TestableHangmanGame(null);
+    personality = new TestableHangmanGame();
   });
 
   it('should create', () => {
@@ -52,9 +111,6 @@ describe('Hangman game', () => {
   });
 
   describe('Game start behaviour', () => {
-    const mockWord = { word: 'ambivalence' };
-    let mockMessage: IMock<Message>;
-
     beforeEach(() => {
       const mockFetchResponse = {
         ok: true,
@@ -75,29 +131,44 @@ describe('Hangman game', () => {
       personality.onMessage(mockMessage.object).then(() => {
         expect(fetchSpy).toHaveBeenCalledWith(apiUrl);
 
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.currentWord).toBe(mockWord.word.toUpperCase());
 
         done();
       });
     });
 
-    it('should add game state for guild on start', (done) => {
-      expect(personality.gameStateMap.has(mockGuildId)).toBeFalse();
+    it('should add game data for guild on start if not existing', (done) => {
+      expect(personality.gameDataMap.has(mockGuildId)).toBeFalse();
 
       personality.onMessage(mockMessage.object).then(() => {
-        expect(personality.gameStateMap.has(mockGuildId)).toBeTrue();
+        expect(personality.gameDataMap.has(mockGuildId)).toBeTrue();
+        done();
+      });
+    });
+
+    it('should update game data for guild on start', (done) => {
+      personality.addMockGameState(mockGuildId);
+      personality.setGameCompleteByWin(mockGuildId);
+      const oldWord = personality.getStateForGuild(mockGuildId).currentDisplay;
+      expect(oldWord).not.toContain('-');
+
+      personality.onMessage(mockMessage.object).then(() => {
+        const newWord = personality.getStateForGuild(mockGuildId)
+          .currentDisplay;
+
+        expect(newWord).not.toBe(oldWord);
         done();
       });
     });
 
     it('should not start a game if one is in progress', (done) => {
       personality.addMockGameState(mockGuildId);
-      const beforeState = personality.gameStateMap.get(mockGuildId);
+      const beforeState = personality.getStateForGuild(mockGuildId);
 
       personality.onMessage(mockMessage.object).then(() => {
         expect(fetchSpy).not.toHaveBeenCalledWith(apiUrl);
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(beforeState).toEqual(afterState);
         done();
       });
@@ -105,8 +176,6 @@ describe('Hangman game', () => {
   });
 
   describe('Guessing behaviour - single letters', () => {
-    let mockMessage: IMock<Message>;
-
     beforeEach(() => {
       mockMessage = Mock.ofType<Message>();
       mockMessage.setup((s) => s.guild).returns(() => mockGuild.object);
@@ -123,7 +192,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.currentDisplay).toContain(guessLetterUC);
         done();
       });
@@ -138,7 +207,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongLetters).not.toContain(guessLetterUC);
         done();
       });
@@ -153,7 +222,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.currentDisplay).not.toContain(guessLetterUC);
         done();
       });
@@ -168,7 +237,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongLetters).toContain(guessLetterUC);
         done();
       });
@@ -176,7 +245,7 @@ describe('Hangman game', () => {
 
     it('should remove life on incorrect letter', (done) => {
       const guessLetter = 'z';
-      const beforeState = personality.gameStateMap.get(mockGuildId);
+      const beforeState = personality.getStateForGuild(mockGuildId);
       const beforeLives = beforeState.livesRemaining;
 
       mockMessage
@@ -184,14 +253,14 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.livesRemaining).toBe(beforeLives - 1);
         done();
       });
     });
 
     it('should not duplicate an incorrect letter', (done) => {
-      const beforeState = personality.gameStateMap.get(mockGuildId);
+      const beforeState = personality.getStateForGuild(mockGuildId);
       const beforeLetterCount = beforeState.wrongLetters.length;
       const guessLetter = beforeState.wrongLetters[0];
 
@@ -200,7 +269,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongLetters.length).toBe(beforeLetterCount);
         done();
       });
@@ -216,7 +285,7 @@ describe('Hangman game', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toContain('not a letter');
 
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongLetters).not.toContain(guessChar);
         done();
       });
@@ -232,7 +301,7 @@ describe('Hangman game', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toContain('not a letter');
 
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongLetters).not.toContain(guessChar);
         done();
       });
@@ -258,7 +327,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessWord}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.currentDisplay).toBe(guessWordUC);
         done();
       });
@@ -273,14 +342,14 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessWord}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongWords).toContain(guessWordUC);
         done();
       });
     });
 
     it('should not duplicate an incorrect word', (done) => {
-      const beforeState = personality.gameStateMap.get(mockGuildId);
+      const beforeState = personality.getStateForGuild(mockGuildId);
       const beforeWordsCount = beforeState.wrongWords.length;
       const guessWord = beforeState.wrongWords[0];
 
@@ -289,7 +358,7 @@ describe('Hangman game', () => {
         .returns(() => `${prefix} ${guessCommand} ${guessWord}`);
 
       personality.onMessage(mockMessage.object).then(() => {
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongWords.length).toBe(beforeWordsCount);
         done();
       });
@@ -305,7 +374,7 @@ describe('Hangman game', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toContain('not a word');
 
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongWords).not.toContain(guessWord);
         done();
       });
@@ -321,8 +390,173 @@ describe('Hangman game', () => {
       personality.onMessage(mockMessage.object).then((response) => {
         expect(response).toContain('not a word');
 
-        const afterState = personality.gameStateMap.get(mockGuildId);
+        const afterState = personality.getStateForGuild(mockGuildId);
         expect(afterState.wrongWords).not.toContain(guessWord);
+        done();
+      });
+    });
+  });
+
+  describe('Statistic summary', () => {
+    const word = 'ABCDE';
+    let startData: GameData;
+
+    beforeEach(() => {
+      mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((s) => s.guild).returns(() => mockGuild.object);
+
+      personality.addBlankGameState(mockGuildId);
+      startData = personality.gameDataMap.get(mockGuildId);
+      startData.state.currentWord = word;
+      startData.state.currentDisplay = word.replace(word[2], '-');
+    });
+
+    it('should return embed showing statistics', (done) => {
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${statsCommand}`);
+
+      personality.onMessage(mockMessage.object).then((response) => {
+        expect(response).toBeInstanceOf(MessageEmbed);
+        done();
+      });
+    });
+
+    it('should add to total wins and win streak if won by word guess', (done) => {
+      const startWins = startData.statistics.totalWins;
+      const startStreak = startData.statistics.currentStreak;
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${guessCommand} ${word}`);
+
+      personality.onMessage(mockMessage.object).then(() => {
+        const currentData = personality.gameDataMap.get(mockGuildId);
+        expect(currentData.statistics.totalWins).toBe(startWins + 1);
+        expect(currentData.statistics.currentStreak).toBe(startStreak + 1);
+        done();
+      });
+    });
+
+    it('should add to total wins and win streak if won by letter guess', (done) => {
+      const startWins = startData.statistics.totalWins;
+      const startStreak = startData.statistics.currentStreak;
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${guessCommand} ${word[2]}`);
+
+      personality.onMessage(mockMessage.object).then(() => {
+        const currentData = personality.gameDataMap.get(mockGuildId);
+        expect(currentData.statistics.totalWins).toBe(startWins + 1);
+        expect(currentData.statistics.currentStreak).toBe(startStreak + 1);
+        done();
+      });
+    });
+
+    it('should add to total losses and clear streak if lost by word guess', (done) => {
+      const startLosses = startData.statistics.totalLosses;
+      startData.state.livesRemaining = 1;
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${guessCommand} ${word.replace('A', 'Z')}`);
+
+      personality.onMessage(mockMessage.object).then(() => {
+        const currentData = personality.gameDataMap.get(mockGuildId);
+        expect(currentData.statistics.totalLosses).toBe(startLosses + 1);
+        expect(currentData.statistics.currentStreak).toBe(0);
+        done();
+      });
+    });
+
+    it('should add to total losses and clear streak if lost by letter guess', (done) => {
+      const startLosses = startData.statistics.totalLosses;
+      startData.state.livesRemaining = 1;
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${guessCommand} z`);
+
+      personality.onMessage(mockMessage.object).then(() => {
+        const currentData = personality.gameDataMap.get(mockGuildId);
+        expect(currentData.statistics.totalLosses).toBe(startLosses + 1);
+        expect(currentData.statistics.currentStreak).toBe(0);
+        done();
+      });
+    });
+
+    it('should keep total losses on incorrect word guess with lives remaining', (done) => {
+      const streak = 5;
+      const startLosses = startData.statistics.totalLosses;
+      startData.state.livesRemaining = 5;
+      startData.statistics.currentStreak = streak;
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${guessCommand} ${word.replace('A', 'Z')}`);
+
+      personality.onMessage(mockMessage.object).then(() => {
+        const currentData = personality.gameDataMap.get(mockGuildId);
+        expect(currentData.statistics.totalLosses).toBe(startLosses);
+        expect(currentData.statistics.currentStreak).toBe(streak);
+        done();
+      });
+    });
+  });
+
+  describe('Multiple guild feature', () => {
+    const altGuildId = 'myaltguild';
+    let altGuildStartState: GameState;
+
+    beforeEach(() => {
+      const mockFetchResponse = {
+        ok: true,
+        json: () => Promise.resolve(mockWord)
+      };
+
+      fetchSpy = spyOn(nodeFetch, 'default');
+      fetchSpy.and.returnValue(Promise.resolve(mockFetchResponse));
+
+      mockMessage = Mock.ofType<Message>();
+      mockMessage.setup((s) => s.guild).returns(() => mockGuild.object);
+
+      personality.addMockGameState(altGuildId);
+      altGuildStartState = { ...personality.getStateForGuild(altGuildId) };
+    });
+
+    it('should not affect existing game if new one started in alternate guild', (done) => {
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${startCommand}`);
+
+      expect(personality.gameDataMap.get(mockGuildId)).toBeFalsy();
+
+      personality.onMessage(mockMessage.object).then(() => {
+        // Other guild not touched
+        const altGuildState = personality.getStateForGuild(altGuildId);
+        expect(altGuildState).toEqual(altGuildStartState);
+
+        // Current guild data added
+        expect(personality.gameDataMap.get(mockGuildId)).toBeTruthy();
+        done();
+      });
+    });
+
+    it('should not affect existing game if guess happens in alternate guild', (done) => {
+      const initialData = personality.addBlankGameState(mockGuildId);
+      initialData.state.currentWord = 'WORD';
+      initialData.state.currentDisplay = '----';
+      initialData.state.livesRemaining = 10;
+      const guessLetter = initialData.state.currentWord[0];
+
+      mockMessage
+        .setup((s) => s.content)
+        .returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
+
+      personality.onMessage(mockMessage.object).then(() => {
+        // Other guild not touched
+        const altGuildState = personality.getStateForGuild(altGuildId);
+        expect(altGuildState).toEqual(altGuildStartState);
+
+        // Current guild data added
+        const gameState = personality.getStateForGuild(mockGuildId);
+        expect(gameState.currentDisplay).toContain(guessLetter);
         done();
       });
     });

--- a/src/personality/hangman-game.ts
+++ b/src/personality/hangman-game.ts
@@ -156,6 +156,10 @@ export class HangmanGame implements Personality {
       return `Bad luck! The word was “${gameState.currentWord}”`;
     }
 
+    if (gameState.currentDisplay.indexOf(guess) >= 0) {
+      return 'You’ve already guessed that!';
+    }
+
     // Copy the letter into the display variable
     for (let index = 0; index < gameState.currentDisplay.length; index += 1) {
       const currentLetter = gameState.currentDisplay[index];

--- a/src/personality/hangman-game.ts
+++ b/src/personality/hangman-game.ts
@@ -1,19 +1,19 @@
-import { Message } from 'discord.js';
+import { Message, MessageEmbed } from 'discord.js';
 import * as nodeFetch from 'node-fetch';
 
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
-import { apiUrl, blankDisplayChar, guessCommand, prefix, startCommand } from './constants/hangman-game';
-import { generateGameEmbed, generateHelpEmbed } from './embeds/hangman-game';
-import { GameState, WordData } from './interfaces/hangman-game';
+import { apiUrl, blankDisplayChar, guessCommand, prefix, startCommand, statsCommand } from './constants/hangman-game';
+import { generateGameEmbed, generateHelpEmbed, generateStatsEmbed } from './embeds/hangman-game';
+import { GameData, GameState, GameStatistics, WordData } from './interfaces/hangman-game';
 import { isGameActive } from './utilities/hangman-game';
 
 export class HangmanGame implements Personality {
-  protected gameStates: Map<string, GameState>;
+  protected gameData: Map<string, GameData>;
 
   constructor(private dependencies: DependencyContainer) {
-    this.gameStates = new Map<string, GameState>();
+    this.gameData = new Map<string, GameData>();
   }
 
   onAddressed(): Promise<MessageType> {
@@ -39,7 +39,11 @@ export class HangmanGame implements Personality {
       return Promise.resolve(this.handleGuess(message.guild.id, guess));
     }
 
-    return this.handleBlankCommand(message.guild.id);
+    if (text.startsWith(statsCommand)) {
+      return this.handleSummaryCommand(message.guild.id, generateStatsEmbed);
+    }
+
+    return this.handleSummaryCommand(message.guild.id, generateGameEmbed);
   }
 
   onHelp(): Promise<MessageType> {
@@ -47,8 +51,9 @@ export class HangmanGame implements Personality {
   }
 
   private handleGameStart(guildId: string): Promise<MessageType> {
-    if (isGameActive(this.gameStates.get(guildId))) {
-      return Promise.resolve('Game already running');
+    const guildGame = this.gameData.get(guildId);
+    if (guildGame && isGameActive(guildGame.state)) {
+      return Promise.resolve('Game is already running');
     }
 
     return nodeFetch
@@ -67,12 +72,31 @@ export class HangmanGame implements Personality {
       });
   }
 
+  /**
+   * Begins a new game of Hangman
+   *
+   * @param guildId the id of the guild the request originated from
+   * @param data word data from API
+   * @returns an embed with the new game information
+   */
   private handleWordResponse(guildId: string, data: WordData): MessageType {
     if (!data || !data.word) {
       return 'Could not load word';
     }
 
-    const newGameState: GameState = {
+    let statistics: GameStatistics;
+    const currentData = this.gameData.get(guildId);
+    if (currentData) {
+      statistics = currentData.statistics;
+    } else {
+      statistics = {
+        totalWins: 0,
+        totalLosses: 0,
+        currentStreak: 0
+      };
+    }
+
+    const state: GameState = {
       timeStarted: Date.now(),
       currentWord: data.word.toUpperCase(),
       currentDisplay: Array(data.word.length).fill('-').join(''),
@@ -81,13 +105,21 @@ export class HangmanGame implements Personality {
       wrongWords: []
     };
 
-    this.gameStates.set(guildId, newGameState);
-    return generateGameEmbed(newGameState);
+    const updatedData = { state, statistics };
+    this.gameData.set(guildId, updatedData);
+    return generateGameEmbed(updatedData);
   }
 
+  /**
+   * Wrapper function to handle guessing of letters or words
+   *
+   * @param guildId the id of the guild the request originated from
+   * @param guess letter or word guessed
+   * @returns game information or help texts
+   */
   private handleGuess(guildId: string, guess: string): MessageType {
-    const gameState = this.gameStates.get(guildId);
-    const gameRunning = isGameActive(gameState);
+    const gameData = this.gameData.get(guildId);
+    const gameRunning = gameData && isGameActive(gameData.state);
     if (!gameRunning) {
       return 'ikke startet';
     }
@@ -106,31 +138,36 @@ export class HangmanGame implements Personality {
       return 'That’s not a word I can use here.';
     }
 
-    // Grab a reference
-    const gameState = this.gameStates.get(guildId);
+    // Grab a reference to the game data
+    const gameData = this.gameData.get(guildId);
+    const { state, statistics } = gameData;
 
-    if (guess.length !== gameState.currentWord.length) {
-      const wordText = `${gameState.currentWord.length}`;
+    if (guess.length !== state.currentWord.length) {
+      const wordText = `${state.currentWord.length}`;
       return `Your guess has ${guess.length} letters, the word has ${wordText}. Think about that for a while.`;
     }
 
-    if (guess === gameState.currentWord) {
-      gameState.currentDisplay = gameState.currentWord;
+    if (guess === state.currentWord) {
+      state.currentDisplay = state.currentWord;
+      statistics.currentStreak += 1;
+      statistics.totalWins += 1;
       return `Yup, it’s “${guess}”`;
     }
 
-    if (gameState.wrongWords.indexOf(guess) !== -1) {
-      return 'You’ve already guessed that one!';
+    if (state.wrongWords.indexOf(guess) !== -1) {
+      return 'That’s already been guessed.';
     }
 
-    gameState.livesRemaining -= 1;
-    gameState.wrongWords.push(guess);
+    state.livesRemaining -= 1;
+    state.wrongWords.push(guess);
 
-    if (gameState.livesRemaining <= 0) {
-      return `You’ve lost! The word was “${gameState.currentWord}”`;
+    if (state.livesRemaining <= 0) {
+      statistics.currentStreak = 0;
+      statistics.totalLosses += 1;
+      return `You’ve lost! The word was “${state.currentWord}”`;
     }
 
-    return generateGameEmbed(gameState);
+    return generateGameEmbed(gameData);
   }
 
   private onGuessLetter(guildId: string, guess: string): MessageType {
@@ -138,59 +175,68 @@ export class HangmanGame implements Personality {
       return 'That’s not a letter I can use…';
     }
 
-    // Grab a reference
-    const gameState = this.gameStates.get(guildId);
+    // Grab a reference to the game data
+    const gameData = this.gameData.get(guildId);
+    const { state, statistics } = gameData;
 
-    if (gameState.currentWord.indexOf(guess) === -1) {
-      if (gameState.wrongLetters.includes(guess)) {
-        return 'You’ve already guessed that!';
+    if (state.currentWord.indexOf(guess) === -1) {
+      if (state.wrongLetters.includes(guess)) {
+        return 'This letter’s already been guessed!';
       }
 
-      gameState.wrongLetters.push(guess);
-      gameState.livesRemaining -= 1;
+      state.wrongLetters.push(guess);
+      state.wrongLetters.sort();
+      state.livesRemaining -= 1;
 
-      if (gameState.livesRemaining > 0) {
-        return `Nope, there’s no “${guess}”. You’ve got ${gameState.livesRemaining} chances remaining!`;
+      if (state.livesRemaining > 0) {
+        return `Nope, there’s no “${guess}”. You’ve got ${state.livesRemaining} chances remaining!`;
       }
 
-      return `Bad luck! The word was “${gameState.currentWord}”`;
+      statistics.currentStreak = 0;
+      statistics.totalLosses += 1;
+      return `Bad luck! The word was “${state.currentWord}”`;
     }
 
-    if (gameState.currentDisplay.indexOf(guess) >= 0) {
-      return 'You’ve already guessed that!';
+    if (state.currentDisplay.indexOf(guess) >= 0) {
+      return 'This letter’s already been guessed!';
     }
 
     // Copy the letter into the display variable
-    for (let index = 0; index < gameState.currentDisplay.length; index += 1) {
-      const currentLetter = gameState.currentDisplay[index];
+    for (let index = 0; index < state.currentDisplay.length; index += 1) {
+      const currentLetter = state.currentDisplay[index];
       if (currentLetter !== blankDisplayChar) {
         continue;
       }
 
-      if (gameState.currentWord[index] !== guess) {
+      if (state.currentWord[index] !== guess) {
         continue;
       }
 
-      const lettersBefore = gameState.currentDisplay.substring(0, index);
-      const lettersAfter = gameState.currentDisplay.substring(index + 1);
-      gameState.currentDisplay = `${lettersBefore}${guess}${lettersAfter}`;
+      const lettersBefore = state.currentDisplay.substring(0, index);
+      const lettersAfter = state.currentDisplay.substring(index + 1);
+      state.currentDisplay = `${lettersBefore}${guess}${lettersAfter}`;
     }
 
-    if (gameState.currentWord === gameState.currentDisplay) {
-      return `Yup, it’s “${gameState.currentWord}”`;
+    if (state.currentWord === state.currentDisplay) {
+      statistics.currentStreak += 1;
+      statistics.totalWins += 1;
+      return `Yup, it’s “${state.currentWord}”`;
     }
 
-    return generateGameEmbed(gameState);
+    return generateGameEmbed(gameData);
   }
 
-  private handleBlankCommand(guildId: string): Promise<MessageType> {
-    const state = this.gameStates.get(guildId);
-    if (!state) {
+  private handleSummaryCommand(
+    guildId: string,
+    embedGen: (input: GameData) => MessageEmbed
+  ): Promise<MessageType> {
+    const data = this.gameData.get(guildId);
+    if (!data) {
       const message =
         'No game has been played - try starting one with `+hm start`';
       return Promise.resolve(message);
     }
 
-    return Promise.resolve(generateGameEmbed(state));
+    return Promise.resolve(embedGen(data));
   }
 }

--- a/src/personality/interfaces/hangman-game.ts
+++ b/src/personality/interfaces/hangman-game.ts
@@ -1,4 +1,13 @@
 /**
+ * Encapsulates the game statistics for the Hangman game
+ */
+export interface GameStatistics {
+  totalWins: number;
+  totalLosses: number;
+  currentStreak: number;
+}
+
+/**
  * Encapsulates the basic game state for the Hangman game
  */
 export interface GameState {
@@ -8,6 +17,14 @@ export interface GameState {
   livesRemaining: number;
   wrongLetters: string[];
   wrongWords: string[];
+}
+
+/**
+ * Encapsulates game data for the Hangman game
+ */
+export interface GameData {
+  state: GameState;
+  statistics: GameStatistics;
 }
 
 /**


### PR DESCRIPTION
This set of changes has been implemented due to two major requests:
- The ability to restart the bot and not lose any progress
- The ability to see total wins and losses, as wel as the current win streak

This is being released as part of the 0.1.x series as 0.2.x with the improved settings persistence is not ready yet.

The game data is read from disc on bot initialise and saved as the bot closes. Stats are viewed by using the new `+hm stats` command.