### PR TITLE
Add ability to add and update rows in the bot's SQLite database

### DIFF
--- a/src/engine/response-generator-impl.ts
+++ b/src/engine/response-generator-impl.ts
@@ -8,6 +8,10 @@ const collectionName = 'responses';
 
 export const NoResponseText = 'Nothing to say to that…';
 
+interface PhraseResponse {
+  text: string;
+}
+
 /**
  * Used to randomly select a response from a collection of responses
  */
@@ -53,7 +57,7 @@ export class ResponseGeneratorImpl implements ResponseGenerator {
       });
     }
 
-    const responses = await this.database.getRecordsFromCollection(
+    const responses = await this.database.getRecordsFromCollection<PhraseResponse>(
       collectionName,
       filter
     );

--- a/src/engine/sqlite-wrapper.spec.ts
+++ b/src/engine/sqlite-wrapper.spec.ts
@@ -171,7 +171,7 @@ describe('SQLite wrapper', () => {
       testObject.dbInstance = mockSqlite.object;
 
       testObject
-        .getRecordsFromCollection(expectedCollection, {})
+        .getRecordsFromCollection<KeyedObject>(expectedCollection, {})
         .then((records: KeyedObject[]) => {
           mockSqlite.verify(
             (m) => m.prepare(It.isValue(`SELECT * FROM ${expectedCollection}`)),

--- a/src/engine/sqlite-wrapper.spec.ts
+++ b/src/engine/sqlite-wrapper.spec.ts
@@ -1,13 +1,25 @@
 import * as sqlite from 'sqlite3';
 import { IMock, It, Mock, Times } from 'typemoq';
 
+import { KeyedObject } from '../interfaces/keyed-object';
 import { Logger } from '../interfaces/logger';
 import { SqliteWrapper } from './sqlite-wrapper';
+
+class TestableSqliteWrapper extends SqliteWrapper {
+  public set dbInstance(value: any) {
+    this.db = value;
+  }
+
+  public get dbInstance() {
+    return this.db;
+  }
+}
 
 describe('SQLite wrapper', () => {
   let mockSqlite: IMock<sqlite.Database>;
   let mockStatement: IMock<sqlite.Statement>;
   let mockLogger: IMock<Logger>;
+  let testObject: TestableSqliteWrapper;
 
   beforeEach(() => {
     mockStatement = Mock.ofType<sqlite.Statement>();
@@ -18,185 +30,364 @@ describe('SQLite wrapper', () => {
       .returns(() => mockStatement.object);
 
     mockLogger = Mock.ofType<Logger>();
+
+    testObject = new TestableSqliteWrapper(mockLogger.object);
   });
 
   it('should construct', () => {
-    const testObject = new SqliteWrapper(mockLogger.object);
     expect(testObject).toBeTruthy();
   });
 
-  // Can't work out a way to mock out the Database constructor cleanly so that
-  // This test works properly. Disabling for now.
-  xit('should connect', (done) => {
-    const mockDbConcretion = (file: string, callback: (err: Error) => void) => {
-      callback(null);
-    };
+  describe('Connection logic', () => {
+    // Can't work out a way to mock out the Database constructor cleanly so that
+    // This test works properly. Disabling for now.
+    xit('should connect', (done) => {
+      const mockDbConcretion = (
+        file: string,
+        callback: (err: Error) => void
+      ) => {
+        callback(null);
+      };
 
-    spyOn(sqlite, 'Database').and.returnValue(mockDbConcretion as any);
+      spyOn(sqlite, 'Database').and.returnValue(mockDbConcretion as any);
 
-    const testObject = new SqliteWrapper(mockLogger.object);
-    testObject
-      .connect()
-      .then(() => {
-        const dbHandle = (testObject as any).db;
-        expect(dbHandle).toBeTruthy();
-        expect(dbHandle.fileName).toBe('./bot.sqlite');
-        done();
-      })
-      .catch((err) => fail(err));
+      testObject
+        .connect()
+        .then(() => {
+          const dbHandle = testObject.dbInstance;
+          expect(dbHandle).toBeTruthy();
+          expect(dbHandle.fileName).toBe('./bot.sqlite');
+          done();
+        })
+        .catch((err) => fail(err));
+    });
+
+    it('should not attempt to reconnect if there is already a connection object', (done) => {
+      testObject.dbInstance = {};
+
+      testObject
+        .connect()
+        .then(() => fail('Should not get here'))
+        .catch((err: Error) => {
+          expect(err).toBeTruthy();
+          done();
+        });
+    });
+
+    it('should disconnect if connected', (done) => {
+      const mySqlite = {
+        close(cb: () => void) {
+          cb();
+        }
+      };
+
+      const spy = spyOn(mySqlite, 'close').and.callThrough();
+
+      testObject.dbInstance = mySqlite;
+
+      testObject
+        .disconnect()
+        .then(() => {
+          expect(spy).toHaveBeenCalled();
+          done();
+        })
+        .catch(() => fail('Should not get here'));
+    });
+
+    it('should not reject when trying to disconnect if not connected', (done) => {
+      testObject
+        .disconnect()
+        .then(() => {
+          expect().nothing();
+          done();
+        })
+        .catch(() => {
+          fail('Throwing when disconnecting when not connected');
+        });
+    });
+
+    it('should bubble up error and reject if disconnect fails', (done) => {
+      const expectedError = 'ERROR';
+      const mySqlite = {
+        close(cb: (err: Error) => void) {
+          cb(new Error(expectedError));
+        }
+      };
+
+      testObject.dbInstance = mySqlite;
+
+      testObject
+        .disconnect()
+        .then(() => fail('Should not get here'))
+        .catch((err: Error) => {
+          expect(err).toBeTruthy();
+          expect(err.message).toBe(expectedError);
+          done();
+        });
+    });
   });
 
-  it('should not attempt to reconnect if there is already a connection object', (done) => {
-    const testObject = new SqliteWrapper(mockLogger.object);
-    (testObject as any).db = {};
+  describe('Getting records', () => {
+    it('should reject when trying to get records and not connected', (done) => {
+      testObject
+        .getRecordsFromCollection('any', {})
+        .then(() => fail('Should not get here'))
+        .catch((err: Error) => {
+          expect(err).toBeTruthy();
+          done();
+        });
+    });
 
-    testObject
-      .connect()
-      .then(() => fail('Should not get here'))
-      .catch((err: Error) => {
-        expect(err).toBeTruthy();
-        done();
-      });
+    it('should handle error returned from getting a collection', (done) => {
+      const expectedError = 'ERROR';
+      mockStatement
+        .setup((m) => m.all(It.isAny(), It.isAny()))
+        .callback((_: unknown, cb: (err: Error) => void) => {
+          cb(new Error(expectedError));
+        });
+
+      testObject.dbInstance = mockSqlite.object;
+
+      testObject
+        .getRecordsFromCollection('any', {})
+        .then(() => fail('Should not get here'))
+        .catch((err: Error) => {
+          expect(err.message).toBe(expectedError);
+          done();
+        });
+    });
+
+    it('should get all records from a collection', (done) => {
+      const expectedCollection = 'myCollection';
+      const mockRows = [{ id: 0 }, { id: 1 }];
+      mockStatement
+        .setup((m) => m.all(It.isAny(), It.isAny()))
+        .callback(
+          (_: unknown, cb: (err: Error, rows: KeyedObject[]) => void) => {
+            cb(null, mockRows);
+          }
+        );
+
+      testObject.dbInstance = mockSqlite.object;
+
+      testObject
+        .getRecordsFromCollection(expectedCollection, {})
+        .then((records: KeyedObject[]) => {
+          mockSqlite.verify(
+            (m) => m.prepare(It.isValue(`SELECT * FROM ${expectedCollection}`)),
+            Times.once()
+          );
+          expect(records).toEqual(mockRows);
+          done();
+        })
+        .catch((err) => fail(err));
+    });
+
+    it('should correctly build SQL statement when filter has been applied', (done) => {
+      const filter = {
+        where: [
+          { field: 'a', value: 'a' },
+          { field: 'b', value: 'b' }
+        ]
+      };
+      mockStatement
+        .setup((m) => m.all(It.isAny(), It.isAny()))
+        .callback(
+          (_: unknown, cb: (err: Error, rows: KeyedObject[]) => void) => {
+            cb(null, []);
+          }
+        );
+
+      testObject.dbInstance = mockSqlite.object;
+
+      testObject
+        .getRecordsFromCollection('col', filter)
+        .then(() => {
+          mockSqlite.verify(
+            (m) => m.prepare(It.isValue(`SELECT * FROM col WHERE a=? AND b=?`)),
+            Times.once()
+          );
+          done();
+        })
+        .catch((err) => fail(err));
+    });
   });
 
-  it('should disconnect if connected', (done) => {
-    const mySqlite = {
-      close(cb: () => void) {
-        cb();
-      }
-    };
+  describe('Insert record functionality', () => {
+    beforeEach(() => {
+      testObject.dbInstance = mockSqlite.object;
+    });
 
-    const spy = spyOn(mySqlite, 'close').and.callThrough();
+    it('should fix field keys that do not have $-prefix keys', (done) => {
+      let lastQueryObject: KeyedObject;
 
-    const testObject = new SqliteWrapper(mockLogger.object);
-    (testObject as any).db = mySqlite;
+      const fields = {
+        bad: 'key'
+      };
 
-    testObject
-      .disconnect()
-      .then(() => {
-        expect(spy).toHaveBeenCalled();
-        done();
-      })
-      .catch(() => fail('Should not get here'));
-  });
+      mockSqlite
+        .setup((m) => m.run(It.isAny(), It.isAny(), It.isAny()))
+        .callback(
+          (_: string, params: KeyedObject, cb: (err: Error) => void) => {
+            lastQueryObject = params;
+            cb(null);
+          }
+        );
 
-  it('should not reject when trying to disconnect if not connected', (done) => {
-    const testObject = new SqliteWrapper(mockLogger.object);
-
-    testObject
-      .disconnect()
-      .then(() => {
-        expect().nothing();
-        done();
-      })
-      .catch(() => {
-        fail('Throwing when disconnecting when not connected');
-      });
-  });
-
-  it('should bubble up error and reject if disconnect fails', (done) => {
-    const expectedError = 'ERROR';
-    const mySqlite = {
-      close(cb: (err: any) => void) {
-        cb(new Error(expectedError));
-      }
-    };
-
-    const testObject = new SqliteWrapper(mockLogger.object);
-    (testObject as any).db = mySqlite;
-
-    testObject
-      .disconnect()
-      .then(() => fail('Should not get here'))
-      .catch((err: Error) => {
-        expect(err).toBeTruthy();
-        expect(err.message).toBe(expectedError);
+      testObject.insertRecordsToCollection('anytable', fields).then(() => {
+        const keys = Object.keys(lastQueryObject);
+        expect(keys.every((key) => key.startsWith('$'))).toBeTrue();
         done();
       });
-  });
+    });
 
-  it('should reject when trying to get records and not connected', (done) => {
-    const testObject = new SqliteWrapper(mockLogger.object);
+    it('should format the input objects into a SQL prepared statement', (done) => {
+      const mockTable = 'anyTable';
 
-    testObject
-      .getRecordsFromCollection('any', {})
-      .then(() => fail('Should not get here'))
-      .catch((err: Error) => {
-        expect(err).toBeTruthy();
-        done();
-      });
-  });
+      const fields = {
+        $product: 'a sample',
+        $quantity: 4
+      };
 
-  it('should handle error returned from getting a collection', (done) => {
-    const expectedError = 'ERROR';
-    mockStatement
-      .setup((m) => m.all(It.isAny(), It.isAny()))
-      .callback((filter: any, cb: (err: any) => void) => {
-        cb(new Error(expectedError));
-      });
+      mockSqlite
+        .setup((m) => m.run(It.isAny(), It.isAny(), It.isAny()))
+        .callback((tb: string, _: unknown, cb: (err: Error) => void) => {
+          expect(tb).toContain(`INSERT INTO ${mockTable}`);
+          cb(null);
+        });
 
-    const testObject = new SqliteWrapper(mockLogger.object);
-    (testObject as any).db = mockSqlite.object;
-
-    testObject
-      .getRecordsFromCollection('any', {})
-      .then(() => fail('Should not get here'))
-      .catch((err: Error) => {
-        expect(err.message).toBe(expectedError);
-        done();
-      });
-  });
-
-  it('should get all records from a collection', (done) => {
-    const expectedCollection = 'myCollection';
-    const mockRows = [{ id: 0 }, { id: 1 }];
-    mockStatement
-      .setup((m) => m.all(It.isAny(), It.isAny()))
-      .callback((filter: any, cb: (err: any, rows: any[]) => void) => {
-        cb(null, mockRows);
-      });
-
-    const testObject = new SqliteWrapper(mockLogger.object);
-    (testObject as any).db = mockSqlite.object;
-
-    testObject
-      .getRecordsFromCollection(expectedCollection, {})
-      .then((records: any[]) => {
+      testObject.insertRecordsToCollection(mockTable, fields).then(() => {
         mockSqlite.verify(
-          (m) => m.prepare(It.isValue(`SELECT * FROM ${expectedCollection}`)),
+          (m) => m.run(It.isAnyString(), It.isObjectWith(fields), It.isAny()),
           Times.once()
         );
-        expect(records).toEqual(mockRows);
+
         done();
-      })
-      .catch((err) => fail(err));
+      });
+    });
   });
 
-  it('should correctly build SQL statement when filter has been applied', (done) => {
-    const filter = {
-      where: [
-        { field: 'a', value: 'a' },
-        { field: 'b', value: 'b' }
-      ]
-    };
-    mockStatement
-      .setup((m) => m.all(It.isAny(), It.isAny()))
-      .callback((f: any, cb: (err: any, rows: any[]) => void) => {
-        cb(null, []);
-      });
+  describe('Update record functionality', () => {
+    beforeEach(() => {
+      testObject.dbInstance = mockSqlite.object;
+    });
 
-    const testObject = new SqliteWrapper(mockLogger.object);
-    (testObject as any).db = mockSqlite.object;
+    it('should fix field keys that do not have $-prefix', (done) => {
+      let lastQueryObject: KeyedObject;
 
-    testObject
-      .getRecordsFromCollection('col', filter)
-      .then(() => {
-        mockSqlite.verify(
-          (m) => m.prepare(It.isValue(`SELECT * FROM col WHERE a=? AND b=?`)),
-          Times.once()
+      const fields = {
+        bad: 'key'
+      };
+
+      const where = {
+        $key: 'value'
+      };
+
+      mockSqlite
+        .setup((m) => m.run(It.isAny(), It.isAny(), It.isAny()))
+        .callback(
+          (_: string, params: KeyedObject, cb: (err: Error) => void) => {
+            lastQueryObject = params;
+            cb(null);
+          }
         );
-        done();
-      })
-      .catch((err) => fail(err));
+
+      testObject
+        .updateRecordsInCollection('anytable', fields, where)
+        .then(() => {
+          const keys = Object.keys(lastQueryObject);
+          expect(keys.every((key) => key.startsWith('$'))).toBeTrue();
+          done();
+        });
+    });
+
+    it('should fix where clause keys that do not have $-prefix', (done) => {
+      let lastQueryObject: KeyedObject;
+
+      const fields = {
+        $key: 'value'
+      };
+
+      const where = {
+        bad: 'key'
+      };
+
+      mockSqlite
+        .setup((m) => m.run(It.isAny(), It.isAny(), It.isAny()))
+        .callback(
+          (_: string, params: KeyedObject, cb: (err: Error) => void) => {
+            lastQueryObject = params;
+            cb(null);
+          }
+        );
+
+      testObject
+        .updateRecordsInCollection('anytable', fields, where)
+        .then(() => {
+          const keys = Object.keys(lastQueryObject);
+          expect(keys.every((key) => key.startsWith('$'))).toBeTrue();
+          done();
+        });
+    });
+
+    it('should format the input objects into a SQL prepared statement', (done) => {
+      const mockTable = 'anyTable';
+
+      const fields = {
+        $product: 'a sample',
+        $quantity: 4
+      };
+
+      const where = {
+        $id: '12345id'
+      };
+
+      mockSqlite
+        .setup((m) => m.run(It.isAny(), It.isAny(), It.isAny()))
+        .callback((tb: string, _: unknown, cb: (err: Error) => void) => {
+          expect(tb).toContain(`UPDATE ${mockTable}`);
+          cb(null);
+        });
+
+      testObject
+        .updateRecordsInCollection(mockTable, fields, where)
+        .then(() => {
+          mockSqlite.verify(
+            (m) =>
+              m.run(
+                It.isAnyString(),
+                It.isObjectWith({ ...fields, ...where }),
+                It.isAny()
+              ),
+            Times.once()
+          );
+
+          done();
+        });
+    });
+
+    it('should reject if query raises an error', (done) => {
+      const fields = {
+        $key: 'value'
+      };
+
+      const where = {
+        $any: 'key'
+      };
+
+      mockSqlite
+        .setup((m) => m.run(It.isAny(), It.isAny(), It.isAny()))
+        .callback((_: unknown, __: unknown, cb: (err: Error) => void) => {
+          cb(new Error('Hello I am a mock error'));
+        });
+
+      testObject
+        .updateRecordsInCollection('anytable', fields, where)
+        .then(() => fail('Query errored but wrapper did not handle'))
+        .catch((err) => {
+          expect(err).toBeTruthy();
+          done();
+        });
+    });
   });
 });

--- a/src/engine/sqlite-wrapper.ts
+++ b/src/engine/sqlite-wrapper.ts
@@ -50,10 +50,10 @@ export class SqliteWrapper implements Database {
     });
   }
 
-  public getRecordsFromCollection(
+  public getRecordsFromCollection<T>(
     collectionName: string,
     filter: QueryFilter
-  ): Promise<any[]> {
+  ): Promise<T[]> {
     if (this.db === null) {
       return Promise.reject(new Error('No connection established'));
     }
@@ -83,7 +83,7 @@ export class SqliteWrapper implements Database {
     return new Promise((resolve, reject) => {
       const sql = `SELECT * FROM ${collectionName}${where}`;
       const statement = this.db.prepare(sql);
-      statement.all(vals, (err: Error, rows: any[]) => {
+      statement.all(vals, (err: Error, rows: T[]) => {
         statement.finalize();
 
         if (err) {

--- a/src/interfaces/database.ts
+++ b/src/interfaces/database.ts
@@ -1,3 +1,5 @@
+import { KeyedObject } from './keyed-object';
+
 export enum QueryLogic {
   And = 'AND',
   Or = 'OR',
@@ -43,4 +45,28 @@ export interface Database {
     collectionName: string,
     filter: QueryFilter
   ): Promise<any[]>;
+
+  /**
+   * Inserts a record into a collection
+   *
+   * @param collectionName the collection to add to
+   * @param values the key-value pairs
+   */
+  insertRecordsToCollection(
+    collectionName: string,
+    values: KeyedObject
+  ): Promise<void>;
+
+  /**
+   * Updates a set of records in a table
+   *
+   * @param collectionName collection to modify
+   * @param fields records to update with values
+   * @param where query filter
+   */
+  updateRecordsInCollection(
+    collectionName: string,
+    fields: KeyedObject,
+    where: KeyedObject
+  ): Promise<void>;
 }

--- a/src/interfaces/database.ts
+++ b/src/interfaces/database.ts
@@ -41,10 +41,10 @@ export interface Database {
    * @param collectionName the collection to get
    * @param filter a filter for results
    */
-  getRecordsFromCollection(
+  getRecordsFromCollection<T>(
     collectionName: string,
     filter: QueryFilter
-  ): Promise<any[]>;
+  ): Promise<T[]>;
 
   /**
    * Inserts a record into a collection

--- a/src/interfaces/keyed-object.ts
+++ b/src/interfaces/keyed-object.ts
@@ -1,0 +1,3 @@
+export interface KeyedObject {
+  [key: string]: unknown;
+}

--- a/src/personality/call-response.ts
+++ b/src/personality/call-response.ts
@@ -4,6 +4,10 @@ import { Database } from '../interfaces/database';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 
+interface CannedResponse {
+  response: string;
+}
+
 /**
  * Call-Response personality
  *
@@ -39,7 +43,7 @@ export class CallResponse implements Personality {
     };
 
     return this.database
-      .getRecordsFromCollection('call_response', filter)
+      .getRecordsFromCollection<CannedResponse>('call_response', filter)
       .then((messagePairs) => {
         if (!messagePairs || messagePairs.length === 0) {
           return null;


### PR DESCRIPTION
This change set extends the SQLite wrapper class to enable insertion and updates of records. It is envisioned as a way to reduce the disparate implementations of persistence for each bot plugin by allowing them to persist settings in their own collection in the database.