### PR TITLE
Prepare version 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+Release 0.2.0 - SQL persistence
+This release lays the groundwork for persisting bot settings using the SQL database
+
+0372ba96dc8e958f1cbb007f57673e6651b294eb Add tally feature to test new SQL persistence implementation
+273ba7bbbd174ed33255fa3e806ab2984c9b16c1 Convert Hangman Game personality to use SQL persistence
+fcbd228c070a35598b2c39cdf29b3b449ca60ac9 Refactor game helper utilities to a separate file
+bac2f689c4d3a52735fd61f40c90f40711378886 Restore multi-guild specs
+4c7510992c5e3afb36fff040ded2a66895012eac Remove init/destroy settings persistence tests
+
 release 0.1.15 - minor feature request: jokes
 b2bf802077db561f8b8b8b57f6f87c57851e0789 Implement basic functionality to fetch jokes from an API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "iris-bot",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.15",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "discord.js": "12.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.1.15",
+  "version": "0.2.0",
   "description": "Discord chatbot",
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",


### PR DESCRIPTION
Bumps the version to 0.2.0:
- SQL persistence features implemented (#65)
- First "legacy persistence" core converted to new persistence model (#70)