### PR TITLE
Reconfigure linting rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "printWidth": 160
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/import-sorter.json
+++ b/import-sorter.json
@@ -1,7 +1,7 @@
 {
   "generalConfiguration.sortOnBeforeSave": true,
   "importStringConfiguration.maximumNumberOfImportExpressionsPerLine.type": "newLineEachExpressionAfterCountLimitExceptIfOnlyOne",
-  "importStringConfiguration.maximumNumberOfImportExpressionsPerLine.count": 80,
+  "importStringConfiguration.maximumNumberOfImportExpressionsPerLine.count": 160,
   "importStringConfiguration.tabSize": 2,
   "importStringConfiguration.quoteMark": "single"
 }


### PR DESCRIPTION
- Enable format on save.
- Increased line length to fix readability issues that have occurred recently.
- Removed parens for well-defined single argument arrow functions.