### PR TITLE
Prepare version 0.2.1 - Hangman game fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+Release 0.2.1 - Hangman game fixes
+From this release forward, we'll switch to using PRs as change history. Using
+commits is not useful for users, and developers can already see these in the repo.
+
+This release contains
+
+- Reconfigure linting rules (#74)
+  Enables autoformat on file saving and adjusts formatting rules for easier reading
+- Hangman game feature fixes (#75)
+  Reformats the game summary to use inline fields to take up less space, and fixes
+  incorrect guessing of full words
+
 Release 0.2.0 - SQL persistence
 This release lays the groundwork for persisting bot settings using the SQL database
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "iris-bot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "discord.js": "12.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Discord chatbot",
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",


### PR DESCRIPTION
From this release forward, we'll switch to using PRs as change history (here and in the CHANGELOG file). Using commits is not useful for users, and developers can already see these in the repo.

This release contains

- #74
  Enables autoformat on file saving and adjusts formatting rules for easier reading
- #75
  Reformats the game summary to use inline fields to take up less space, and fixes incorrect guessing of full words