### PR TITLE
Restore MC online status to embed title

### DIFF
--- a/src/personality/embeds/mc-server.spec.ts
+++ b/src/personality/embeds/mc-server.spec.ts
@@ -29,10 +29,10 @@ describe('Embed formatting for Minecraft server utilities', () => {
 
     const offlineEmbed = embeds.generateServerEmbed(serverUrl, null);
 
-    it('should have status in description', () => {
-      expect(onlinePlayersEmbed.description).toContain('online');
-      expect(onlineEmptyEmbed.description).toContain('online');
-      expect(offlineEmbed.description).toContain('offline');
+    it('should have status in title', () => {
+      expect(onlinePlayersEmbed.title).toContain('online');
+      expect(onlineEmptyEmbed.title).toContain('online');
+      expect(offlineEmbed.title).toContain('offline');
     });
 
     it('should have server address in title', () => {

--- a/src/personality/embeds/mc-server.ts
+++ b/src/personality/embeds/mc-server.ts
@@ -44,8 +44,8 @@ export function generateServerEmbed(url: string, status: ServerResponse): Messag
   const statusText = isOnline ? 'online' : 'offline';
 
   const embed = new MessageEmbed();
-  embed.setTitle(url);
-  embed.setDescription(`${description}\n\nNow ${statusText}`);
+  embed.setTitle(`${url} is ${statusText}`);
+  embed.setDescription(description);
   embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
 
   // Version field

--- a/src/personality/mc-server.spec.ts
+++ b/src/personality/mc-server.spec.ts
@@ -116,7 +116,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then(response => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.description).toContain('online');
+        expect(embed.title).toContain('online');
         done();
       });
     });
@@ -133,7 +133,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then(response => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.description).toContain('offline');
+        expect(embed.title).toContain('offline');
         done();
       });
     });
@@ -150,7 +150,7 @@ describe('Minecraft server utilities', () => {
       personality.onMessage(mockMessage.object).then(response => {
         expect(response).toBeTruthy();
         const embed = response as MessageEmbed;
-        expect(embed.description).toContain('online');
+        expect(embed.title).toContain('online');
         done();
       });
     });
@@ -306,7 +306,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('online');
+        expect(embed.title).toContain('online');
         done();
       });
     });
@@ -324,7 +324,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('offline');
+        expect(embed.title).toContain('offline');
         done();
       });
     });
@@ -342,7 +342,7 @@ describe('Minecraft server utilities', () => {
       personality.invokeFetch();
       setTimeout(() => {
         expect(embed).toBeTruthy();
-        expect(embed.description).toContain('offline');
+        expect(embed.title).toContain('offline');
         done();
       });
     });


### PR DESCRIPTION
Partial revert of #77 

Restores the server status of the Minecraft server status plugin to the embed title to make it easier to see.