### PR TITLE
Make Hangman Game dictionary stats visible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,18 @@
-Release 0.3.1 - personality plugin bugfixes
+# Release 0.3.2 - Hangman Game plugin: word statistics
 
-- The Minecraft Server Status plugin now shows the status in the embed title again.
-- The Hangman Game plugin can now fetch information about the words from the API.
+This release simply the dictionary information embed (#81) visible in the help
+command. It also tweaks the text in that embed to make it more readable.
 
-Release 0.3.0 - Vulnerability reduction, package version bump
+This changelog file has also been reformatted to make it a valid markdown file,
+which shows how bad the automatically-generated parts are.
+
+# Release 0.3.1 - personality plugin bugfixes
+
+- The Minecraft Server Status plugin now shows the status in the embed title again (#80).
+- The Hangman Game plugin can now fetch information about the words from the API (#81).
+
+# Release 0.3.0 - Vulnerability reduction, package version bump
+
 This release switches out vulnerable packages for non-vulnerable (at time of
 writing). It also bumps the disccord.js version to latest. Due to this, the
 minimum NodeJS version has been increased to 16.
@@ -11,11 +20,13 @@ minimum NodeJS version has been increased to 16.
 - node-fetch was replaced with axios
 - sqlite3 was replaced with the vscode fork
 
-Release 0.2.2 - Adjust layout of Minecraft server status embed
+# Release 0.2.2 - Adjust layout of Minecraft server status embed
+
 This release adds the ability to show the server MOTD/Description text in the
 server status messages.
 
-Release 0.2.1 - Hangman game fixes
+# Release 0.2.1 - Hangman game fixes
+
 From this release forward, we'll switch to using PRs as change history. Using
 commits is not useful for users, and developers can already see these in the repo.
 
@@ -27,96 +38,110 @@ This release contains
   Reformats the game summary to use inline fields to take up less space, and fixes
   incorrect guessing of full words
 
-Release 0.2.0 - SQL persistence
+# Release 0.2.0 - SQL persistence
+
 This release lays the groundwork for persisting bot settings using the SQL database
 
-0372ba96dc8e958f1cbb007f57673e6651b294eb Add tally feature to test new SQL persistence implementation
-273ba7bbbd174ed33255fa3e806ab2984c9b16c1 Convert Hangman Game personality to use SQL persistence
-fcbd228c070a35598b2c39cdf29b3b449ca60ac9 Refactor game helper utilities to a separate file
-bac2f689c4d3a52735fd61f40c90f40711378886 Restore multi-guild specs
-4c7510992c5e3afb36fff040ded2a66895012eac Remove init/destroy settings persistence tests
+- 0372ba96dc8e958f1cbb007f57673e6651b294eb Add tally feature to test new SQL persistence implementation
+- 273ba7bbbd174ed33255fa3e806ab2984c9b16c1 Convert Hangman Game personality to use SQL persistence
+- fcbd228c070a35598b2c39cdf29b3b449ca60ac9 Refactor game helper utilities to a separate file
+- bac2f689c4d3a52735fd61f40c90f40711378886 Restore multi-guild specs
+- 4c7510992c5e3afb36fff040ded2a66895012eac Remove init/destroy settings persistence tests
 
-release 0.1.15 - minor feature request: jokes
-b2bf802077db561f8b8b8b57f6f87c57851e0789 Implement basic functionality to fetch jokes from an API
+# release 0.1.15 - minor feature request: jokes
 
-release 0.1.12, 0.1.13 and 0.1.14 - Hangman game bugfixes, statistics and persistence
-16ebf39ea37af62473e3fb0e2ac41562d776fce2 Prevent adding already guessed correct letters
-fe3999df207f997c0eedc60b5607f8e730521bf9 Add GameData and GameStatistics interfaces
-3f50d8493805baa6e03210b5371da223b5dfe253 Implement statistics for hangman game
-2a8d8b6965b9032a1d3fa8be0fed4d4c658524a0 Implement hangman state persistence
-c8fe0a1e62574ed9ddf1f82b56a64763a4e4554a Remove asynchronous call in destroy
-9d63f707f1cc33067bdafe05bd0632f872f182bc Change hangman game default behaviour to show help
+- b2bf802077db561f8b8b8b57f6f87c57851e0789 Implement basic functionality to fetch jokes from an API
 
-Release 0.1.11 - Improved help and third-party stickers:
-93317c9f1b0d70626c36dd23a9eb82178d681fd1 Remove obsolete bot debugging code
-f471977357b6fa41fdaf6a6a7be1b84fa7c66acd Allow bot to respond to different forms of help command
-34944f4713cbb2d742c518b908ce32994ea166dc Rework animal image plugin help message
-c5c89981e26ed801fa90872993bf1e66eafc3663 Move blog roll utilities to utilities folder
-f21e001869c549a6e3c8cc477b87f8fef5634e00 Rework die roll plugin help message
-a55c106e8326822421fb640c8142d8623fd48a7a Rework hugbot plugin help message
-9a741e7fc9546ca6bfb63f97e7a81793d68b1a1f Rework build information help text
-6e51f22fead516ce41aac0fa16d5169c1035b349 Implement basic sticker image personality
-a97e4b1981bb8e8c9b3a993062c20a169b26f3c0 Clean up imports and types
-4aaacfe178079b1a86b387e655fab67896986557 Prepare version 0.1.11
+# release 0.1.12, 0.1.13 and 0.1.14 - Hangman game bugfixes, statistics and persistence
 
-Release 0.1.10 - Hangman personality core:
-22617df7e7a4b0acf59b484f6cdf29da9f359a0a Add boilerplate hangman personality
-fafcf8e486a5499c56e2780cbb49163976855699 Implement fetching of word from API
-8a2c1c48936a96804ef58ce3008f4e980c32448b Implement basic game state
-0860a4ecac647b169add576e02cdef4fc47420ee Implement guessing logic
-3f96c9bd82e424d47803dad046e96ff92a6178c3 Provide embeds for the game play and summary
+- 16ebf39ea37af62473e3fb0e2ac41562d776fce2 Prevent adding already guessed correct letters
+- fe3999df207f997c0eedc60b5607f8e730521bf9 Add GameData and GameStatistics interfaces
+- 3f50d8493805baa6e03210b5371da223b5dfe253 Implement statistics for hangman game
+- 2a8d8b6965b9032a1d3fa8be0fed4d4c658524a0 Implement hangman state persistence
+- c8fe0a1e62574ed9ddf1f82b56a64763a4e4554a Remove asynchronous call in destroy
+- 9d63f707f1cc33067bdafe05bd0632f872f182bc Change hangman game default behaviour to show help
 
-Release 0.1.9 changes:
-9c5113f6810dfc79f75579d75e32170a552ecd08 Update image URLs for FoxBot core
-94f38c3a5851f6d7e6fd9edbbcb2c829c63097a9 Rename FoxBot to AnimalImages
-ffed829b4476722884152bfc8aaf5bb905ff2303 Refactor build information into its own personality core
+# Release 0.1.11 - Improved help and third-party stickers:
 
-Release 0.1.8 changes:
-d799316e050ad8c572901e24925d0cec95ad320b Refactor MCServer plugin embeds into separate file
-f140f3f57c545a294f1acf740b942018bf3c8074 Reorganise server status embed to display information more naturally
+- 93317c9f1b0d70626c36dd23a9eb82178d681fd1 Remove obsolete bot debugging code
+- f471977357b6fa41fdaf6a6a7be1b84fa7c66acd Allow bot to respond to different forms of help command
+- 34944f4713cbb2d742c518b908ce32994ea166dc Rework animal image plugin help message
+- c5c89981e26ed801fa90872993bf1e66eafc3663 Move blog roll utilities to utilities folder
+- f21e001869c549a6e3c8cc477b87f8fef5634e00 Rework die roll plugin help message
+- a55c106e8326822421fb640c8142d8623fd48a7a Rework hugbot plugin help message
+- 9a741e7fc9546ca6bfb63f97e7a81793d68b1a1f Rework build information help text
+- 6e51f22fead516ce41aac0fa16d5169c1035b349 Implement basic sticker image personality
+- a97e4b1981bb8e8c9b3a993062c20a169b26f3c0 Clean up imports and types
+- 4aaacfe178079b1a86b387e655fab67896986557 Prepare version 0.1.11
 
-Release 0.1.7 changes:
-054e2cda02f1cccedefa77654e3c53cb9c6432fb Implement cat picture API route
-15b54a5796f4b767444075bda9aec1b615116143 Bump dependencies with security vulnerabilities
-6a8ab80dd99fdf4a7283320206dffa3e8e617212 Implement server status for initial release servers
-a2e75c5beb96c823a31dc6a1a87d15f817123c74 Parse release version to include in response text
+# Release 0.1.10 - Hangman personality core:
 
-Release 0.1.6 changes:
-b05f8827b83ae4bec387e0e4402fc853357a048b Remove URL from help text
-d3d95157ab15c038e774962a1f9d10ee2da64277 Implement returning of neutral phrases if mood is not neutral
-3ca1ddbc003bc6d997b9ff4c40c3bbf21c4584cd Prepare release 0.1.6
+- 22617df7e7a4b0acf59b484f6cdf29da9f359a0a Add boilerplate hangman personality
+- fafcf8e486a5499c56e2780cbb49163976855699 Implement fetching of word from API
+- 8a2c1c48936a96804ef58ce3008f4e980c32448b Implement basic game state
+- 0860a4ecac647b169add576e02cdef4fc47420ee Implement guessing logic
+- 3f96c9bd82e424d47803dad046e96ff92a6178c3 Provide embeds for the game play and summary
 
-Release 0.1.5 changes:
-a28148d7de315e2b9dc4fd02f01bd24b9a48f8ee Improve robustness of Minecraft Server status
-ca1bc119432bf0e4f0c2ad66656b718debb4dd51 Refactor fetch status code
-f9367905be3b25a6f84880e93668bd9a72b78bd0 Add script to generate changelog
-05d71910d4868c10b1fb3842d7fe0505bf011314 Prepare release 0.1.5
+# Release 0.1.9 changes:
 
-Release 0.1.4 changes:
-ab03b1da16dcf7b93e6a59fd0cc9acfe92093ade Fix problematic build due to import issue
-16dcd125b44b9505fde007ea267ea64e1a4b5df4 Bump sqlite3 dependency
-fc140a1eb3ee712a18d4c821e1c0cba8357c3edc Prepare release 0.1.4
+- 9c5113f6810dfc79f75579d75e32170a552ecd08 Update image URLs for FoxBot core
+- 94f38c3a5851f6d7e6fd9edbbcb2c829c63097a9 Rename FoxBot to AnimalImages
+- ffed829b4476722884152bfc8aaf5bb905ff2303 Refactor build information into its own personality core
 
-Release 0.1.3 changes:
-76e3ee4bae96f92e464116eef06230a4c67fde2c Bootstrap Minecraft interaction
-607523dd4c2a13654b33f71eda9b3efce45c739b Add Minecraft Server helper dependency
-c43087a7d3d09a74f29367f8a4e4a504e7ee12f9 Implement fetching server status by command
-3fd4ef40815e611569e554567fdc56fd3e9ae070 Add ability to associate a Discord server with a Minecraft server
-6d3a719afe48b014147f180929258b4f718f0ce7 Implement association of Discord guild with Minecraft server
-36d0423bfb6452e71a8c9cec33befe2538d0fc45 Implement automatic fetch of server statuses
-13a579f95dfe5bc9b2e88e6887afa605559b7abd Enable persisting settings to file
-4e4230e43c1efa42e41f29932811c7cafca5e659 Enable Minecraft server status personality
+# Release 0.1.8 changes:
 
-Release 0.1.2 changes:
-038c278cbb53d24e1ce2df72b91836c7203fcf87 Improve image core to allow for multiple urls
-3d4f7126262469b721ded8375412efcbfa37664b Implement bot ability to send its own name with shortcut
-6a106c6a66417d4061246d061180c1310cf427aa Add help signature to personality interface
-ab64705f19380195362fa2b0fc2e7a2d60207e58 Implement help request wrapper
-c915af4973f54168869c29c7f57c76f6bf91c310 Add help content to simple interactions personality
-4019f2b28a163b252d3ae78e41beeb0b2f97da74 Add help texts to built-in personalities
-c01d02d6e92a48ece4a750d7dd026b848946e2fa Prepare release 0.1.2
+- d799316e050ad8c572901e24925d0cec95ad320b Refactor MCServer plugin embeds into separate file
+- f140f3f57c545a294f1acf740b942018bf3c8074 Reorganise server status embed to display information more naturally
 
-Release 0.1.1 changes:
-3d4bc8bdaa69ded6095b0e81b5fb82775f33d274 Bump dependencies
-9fad63fe1f66a80aa9ea229d716aa36eea6896a0 Wrap jasmine using ts-node
-793ccdd6fb0706158d6f0b85ddda7b5719274f2c Improve parsing of git commit for readability
+# Release 0.1.7 changes:
+
+- 054e2cda02f1cccedefa77654e3c53cb9c6432fb Implement cat picture API route
+- 15b54a5796f4b767444075bda9aec1b615116143 Bump dependencies with security vulnerabilities
+- 6a8ab80dd99fdf4a7283320206dffa3e8e617212 Implement server status for initial release servers
+- a2e75c5beb96c823a31dc6a1a87d15f817123c74 Parse release version to include in response text
+
+# Release 0.1.6 changes:
+
+- b05f8827b83ae4bec387e0e4402fc853357a048b Remove URL from help text
+- d3d95157ab15c038e774962a1f9d10ee2da64277 Implement returning of neutral phrases if mood is not neutral
+- 3ca1ddbc003bc6d997b9ff4c40c3bbf21c4584cd Prepare release 0.1.6
+
+# Release 0.1.5 changes:
+
+- a28148d7de315e2b9dc4fd02f01bd24b9a48f8ee Improve robustness of Minecraft Server status
+- ca1bc119432bf0e4f0c2ad66656b718debb4dd51 Refactor fetch status code
+- f9367905be3b25a6f84880e93668bd9a72b78bd0 Add script to generate changelog
+- 05d71910d4868c10b1fb3842d7fe0505bf011314 Prepare release 0.1.5
+
+# Release 0.1.4 changes:
+
+- ab03b1da16dcf7b93e6a59fd0cc9acfe92093ade Fix problematic build due to import issue
+- 16dcd125b44b9505fde007ea267ea64e1a4b5df4 Bump sqlite3 dependency
+- fc140a1eb3ee712a18d4c821e1c0cba8357c3edc Prepare release 0.1.4
+
+# Release 0.1.3 changes:
+
+- 76e3ee4bae96f92e464116eef06230a4c67fde2c Bootstrap Minecraft interaction
+- 607523dd4c2a13654b33f71eda9b3efce45c739b Add Minecraft Server helper dependency
+- c43087a7d3d09a74f29367f8a4e4a504e7ee12f9 Implement fetching server status by command
+- 3fd4ef40815e611569e554567fdc56fd3e9ae070 Add ability to associate a Discord server with a Minecraft server
+- 6d3a719afe48b014147f180929258b4f718f0ce7 Implement association of Discord guild with Minecraft server
+- 36d0423bfb6452e71a8c9cec33befe2538d0fc45 Implement automatic fetch of server statuses
+- 13a579f95dfe5bc9b2e88e6887afa605559b7abd Enable persisting settings to file
+- 4e4230e43c1efa42e41f29932811c7cafca5e659 Enable Minecraft server status personality
+
+# Release 0.1.2 changes:
+
+- 038c278cbb53d24e1ce2df72b91836c7203fcf87 Improve image core to allow for multiple urls
+- 3d4f7126262469b721ded8375412efcbfa37664b Implement bot ability to send its own name with shortcut
+- 6a106c6a66417d4061246d061180c1310cf427aa Add help signature to personality interface
+- ab64705f19380195362fa2b0fc2e7a2d60207e58 Implement help request wrapper
+- c915af4973f54168869c29c7f57c76f6bf91c310 Add help content to simple interactions personality
+- 4019f2b28a163b252d3ae78e41beeb0b2f97da74 Add help texts to built-in personalities
+- c01d02d6e92a48ece4a750d7dd026b848946e2fa Prepare release 0.1.2
+
+# Release 0.1.1 changes:
+
+- 3d4bc8bdaa69ded6095b0e81b5fb82775f33d274 Bump dependencies
+- 9fad63fe1f66a80aa9ea229d716aa36eea6896a0 Wrap jasmine using ts-node
+- 793ccdd6fb0706158d6f0b85ddda7b5719274f2c Improve parsing of git commit for readability

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-bot",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-bot",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@vscode/sqlite3": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Discord chatbot",
   "engines": {
     "npm": ">=7.0.0",

--- a/src/personality/embeds/hangman-game.spec.ts
+++ b/src/personality/embeds/hangman-game.spec.ts
@@ -1,4 +1,4 @@
-import { guessCommand, prefix, startCommand, statsCommand } from '../constants/hangman-game';
+import { dictionaryCommand, guessCommand, prefix, startCommand, statsCommand } from '../constants/hangman-game';
 import { DictionaryInfo, GameData } from '../interfaces/hangman-game';
 import { embedColor, embedTitle, generateDictionaryEmbed, generateGameEmbed, generateHelpEmbed, generateStatsEmbed } from './hangman-game';
 
@@ -110,6 +110,14 @@ describe('Hangman Game Help embed', () => {
 
     expect(summaryField).toBeDefined();
     expect(summaryField.value).toContain(statsCommand);
+  });
+
+  it('should contain instructions to view dictionary information', () => {
+    const helpEmbed = generateHelpEmbed();
+    const summaryField = helpEmbed.fields.find(f => f.name.toUpperCase().includes('DICTIONARY'));
+
+    expect(summaryField).toBeDefined();
+    expect(summaryField.value).toContain(dictionaryCommand);
   });
 });
 

--- a/src/personality/embeds/hangman-game.spec.ts
+++ b/src/personality/embeds/hangman-game.spec.ts
@@ -165,7 +165,7 @@ describe('Hangman Game Dictionary Stats embed', () => {
   it('should state total number of words for each letter length', () => {
     const embed = generateDictionaryEmbed(fakeDictStats);
     fakeDictStats.wordLengths.forEach(lengthData => {
-      expect(embed.description).toContain(`*${lengthData.count}* ${lengthData['word-length']} letter words`);
+      expect(embed.description).toContain(`${lengthData['word-length']}-letter words: **${lengthData.count}**`);
     });
   });
 });

--- a/src/personality/embeds/hangman-game.ts
+++ b/src/personality/embeds/hangman-game.ts
@@ -54,7 +54,7 @@ export function generateDictionaryEmbed(statsResponse: DictionaryInfo): MessageE
   const embed = generateBaseEmbed();
   const lines: string[] = [];
   statsResponse.wordLengths.forEach(data => {
-    const formattedData = `• *${data.count}* ${data['word-length']} letter words`;
+    const formattedData = `• ${data['word-length']}-letter words: **${data.count}**`;
     lines.push(formattedData);
   });
 

--- a/src/personality/embeds/hangman-game.ts
+++ b/src/personality/embeds/hangman-game.ts
@@ -1,6 +1,6 @@
 import { MessageEmbed } from 'discord.js';
 
-import { guessCommand, prefix, startCommand, statsCommand, summaryCommand } from '../constants/hangman-game';
+import { dictionaryCommand, guessCommand, prefix, startCommand, statsCommand, summaryCommand } from '../constants/hangman-game';
 import { DictionaryInfo, GameData } from '../interfaces/hangman-game';
 
 export const embedTitle = 'Hangman';
@@ -20,6 +20,7 @@ export function generateHelpEmbed(): MessageEmbed {
   embed.addField('Starting a game', `Use \`${prefix} ${startCommand}\` to start a game.`);
   embed.addField('Making guesses', `Use \`${prefix} ${guessCommand} <your guess>\` to guess a letter or word.`);
   embed.addField('Viewing stats', `Use \`${prefix} ${statsCommand}\` to see the current server stats.`);
+  embed.addField('Dictionary', `Use \`${prefix} ${dictionaryCommand}\` to see the current dictionary information.`);
 
   return embed;
 }


### PR DESCRIPTION
This builds upon #81 to expose the functionality to the end users.

The embed has been refomatted to show word counts in the format `<n>-letter words: <x>`.

I've also reformatted the markdown style in the changelog because it was unreadable when viewed in VS Code's preview pane.