### PR TITLE
Enable message options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+# Release 0.4.0 - Enabling more complex messages using the MessageOptions interface
+
+Discord.JS allows developers to send messages to channels using the
+MessageOptions interface. This interface encapsulates a much more complicated
+message to a channel; for example a text string and an embed. This functionality
+will be useful for more dynamic responses from plugins. Just remember that with
+great power comes great responsibility!
+
+The interface documentation can be found on the [DiscordJS website](https://discord.js.org/#/docs/discord.js/stable/typedef/MessageOptions).
+
 # Release 0.3.2 - Hangman Game plugin: word statistics
 
 This release simply the dictionary information embed (#81) visible in the help

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-bot",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-bot",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/sqlite3": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Discord chatbot",
   "engines": {
     "npm": ">=7.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
-import { MessageEmbed } from 'discord.js';
+import { MessageEmbed, MessageOptions } from 'discord.js';
 
-export type MessageType = string | MessageEmbed;
+/** All-encapsulating type to enable sending of messages to a Text Channel  */
+export type MessageType = string | MessageEmbed | MessageOptions;


### PR DESCRIPTION
The library we are using to connect to Discord, `Discord.JS`, allows developers to send messages to channels using the `MessageOptions` interface. This interface encapsulates a much more complicated message to a channel; for example a text string and an embed. This functionality will be useful for more dynamic responses from plugins.

An example use case would be for the Hangman Game plugin, where an incorrect guess could show the text and the current game state, reducing the requirement for using the `+hm show` command multiple times.

The interface documentation can be found on the [DiscordJS website](https://discord.js.org/#/docs/discord.js/stable/typedef/MessageOptions).