### PR TITLE
Show embed on incorrect guess

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# Release 0.4.1 - Show Hangman Game state on incorrect word guess
+
+This change shows the game state on an incorrect guess so that the show command
+does not need to be run as often.
+
 # Release 0.4.0 - Enabling more complex messages using the MessageOptions interface
 
 Discord.JS allows developers to send messages to channels using the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-bot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-bot",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/sqlite3": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Discord chatbot",
   "engines": {
     "npm": ">=7.0.0",

--- a/src/personality/embeds/hangman-game.spec.ts
+++ b/src/personality/embeds/hangman-game.spec.ts
@@ -1,6 +1,14 @@
 import { dictionaryCommand, guessCommand, prefix, startCommand, statsCommand } from '../constants/hangman-game';
 import { DictionaryInfo, GameData } from '../interfaces/hangman-game';
-import { embedColor, embedTitle, generateDictionaryEmbed, generateGameEmbed, generateHelpEmbed, generateStatsEmbed } from './hangman-game';
+import {
+  embedColorError,
+  embedColorNormal,
+  embedTitle,
+  generateDictionaryEmbed,
+  generateGameEmbed,
+  generateHelpEmbed,
+  generateStatsEmbed
+} from './hangman-game';
 
 const mockStats = {
   totalWins: 5,
@@ -33,7 +41,13 @@ describe('Hangman Game Status embed', () => {
     const gameData: GameData = mockGame;
     const embed = generateGameEmbed(gameData);
     expect(embed.title).toBe(embedTitle);
-    expect(embed.hexColor).toBe(embedColor);
+    expect(embed.hexColor).toBe(embedColorNormal);
+  });
+
+  it('should set colour to error if optional defaultColor param is false', () => {
+    const gameData: GameData = mockGame;
+    const embed = generateGameEmbed(gameData, false);
+    expect(embed.hexColor).toBe(embedColorError);
   });
 
   it('should display current guessed letters', () => {
@@ -77,7 +91,7 @@ describe('Hangman Game Help embed', () => {
   it('should have title and colour defined', () => {
     const embed = generateHelpEmbed();
     expect(embed.title).toBe(embedTitle);
-    expect(embed.hexColor).toBe(embedColor);
+    expect(embed.hexColor).toBe(embedColorNormal);
   });
 
   it('should contain game summary instructions', () => {
@@ -126,7 +140,7 @@ describe('Hangman Game Summary embed', () => {
     const gameData: GameData = mockGame;
     const embed = generateStatsEmbed(gameData);
     expect(embed.title).toBe(embedTitle);
-    expect(embed.hexColor).toBe(embedColor);
+    expect(embed.hexColor).toBe(embedColorNormal);
   });
 
   it('should display total wins', () => {

--- a/src/personality/embeds/hangman-game.ts
+++ b/src/personality/embeds/hangman-game.ts
@@ -4,12 +4,13 @@ import { dictionaryCommand, guessCommand, prefix, startCommand, statsCommand, su
 import { DictionaryInfo, GameData } from '../interfaces/hangman-game';
 
 export const embedTitle = 'Hangman';
-export const embedColor = '#0080ff';
+export const embedColorNormal = '#0080ff';
+export const embedColorError = '#ff8000';
 
-function generateBaseEmbed(): MessageEmbed {
+function generateBaseEmbed(useDefaultColor = true): MessageEmbed {
   const embed = new MessageEmbed();
   embed.setTitle(embedTitle);
-  embed.setColor(embedColor);
+  embed.setColor(useDefaultColor ? embedColorNormal : embedColorError);
   return embed;
 }
 
@@ -25,8 +26,8 @@ export function generateHelpEmbed(): MessageEmbed {
   return embed;
 }
 
-export function generateGameEmbed(gameData: GameData): MessageEmbed {
-  const embed = generateBaseEmbed();
+export function generateGameEmbed(gameData: GameData, useDefaultColor?: boolean): MessageEmbed {
+  const embed = generateBaseEmbed(useDefaultColor);
   const letterDisplay = `\`${gameData.currentDisplay}\``;
   const countDisplay = `(${gameData.currentDisplay.length} letters)`;
   const chanceDisplay = `${gameData.livesRemaining} chances left`;

--- a/src/personality/hangman-game.guess-letter.spec.ts
+++ b/src/personality/hangman-game.guess-letter.spec.ts
@@ -1,4 +1,4 @@
-import { Guild, Message } from 'discord.js';
+import { Guild, Message, MessageEmbed, MessageOptions } from 'discord.js';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { Database } from '../interfaces/database';
@@ -6,6 +6,7 @@ import { DependencyContainer } from '../interfaces/dependency-container';
 import { KeyedObject } from '../interfaces/keyed-object';
 import { Logger } from '../interfaces/logger';
 import { guessCommand, prefix, sqlCollection } from './constants/hangman-game';
+import * as embeds from './embeds/hangman-game';
 import { HangmanGame } from './hangman-game';
 import { mockActiveGame, mockGuildId } from './hangman-game.specdata';
 import { GameData, SerialisableGameData } from './interfaces/hangman-game';
@@ -98,6 +99,33 @@ describe('Hangman Game - guessing behaviour for single letters', () => {
 
     personality.onMessage(mockMessage.object).then(() => {
       expect(afterState.wrongLetters).toContain(guessLetterUC);
+      done();
+    });
+  });
+
+  it('should respond with message about the guess being wrong on incorrect guess', done => {
+    const guessLetter = 'z';
+
+    mockMessage.setup(s => s.content).returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
+
+    personality.onMessage(mockMessage.object).then(response => {
+      const messageOpts = response as MessageOptions;
+      expect(messageOpts.content).toContain(guessLetter.toUpperCase());
+      done();
+    });
+  });
+
+  it('should respond with game embed on incorrect guess', done => {
+    const embedSpy = spyOn(embeds, 'generateGameEmbed').and.returnValue(new MessageEmbed());
+    const guessLetter = 'z';
+    const expectedDefaultColour = false;
+
+    mockMessage.setup(s => s.content).returns(() => `${prefix} ${guessCommand} ${guessLetter}`);
+
+    personality.onMessage(mockMessage.object).then(response => {
+      const messageOpts = response as MessageOptions;
+      expect(messageOpts.embeds.length).toBe(1);
+      expect(embedSpy).toHaveBeenCalledWith(jasmine.anything(), expectedDefaultColour);
       done();
     });
   });

--- a/src/personality/hangman-game.ts
+++ b/src/personality/hangman-game.ts
@@ -194,7 +194,7 @@ export class HangmanGame implements Personality {
 
     if (guess.length !== gameData.currentWord.length) {
       const wordText = `Your guess has ${guess.length} letters, the word has ${gameData.currentWord.length}.`;
-      return Promise.resolve(`${wordText}Think about that for a while.`);
+      return Promise.resolve(wordText);
     }
 
     if (guess === gameData.currentWord) {
@@ -219,7 +219,10 @@ export class HangmanGame implements Personality {
       return this.updateGameForGuild(guildId, gameData).then(() => `You’ve lost! The word was “${gameData.currentWord}”`);
     }
 
-    return this.updateGameForGuild(guildId, gameData).then(() => `Nope, it’s not “${guess}”`);
+    return this.updateGameForGuild(guildId, gameData).then(() => ({
+      content: `Nope, it’s not “${guess}”`,
+      embeds: [generateGameEmbed(gameData, false)]
+    }));
   }
 
   private onGuessLetter(guildId: string, guess: string, gameData: GameData): Promise<MessageType> {
@@ -237,7 +240,10 @@ export class HangmanGame implements Personality {
       gameData.livesRemaining -= 1;
 
       if (gameData.livesRemaining > 0) {
-        return this.updateGameForGuild(guildId, gameData).then(() => `Nope, there’s no “${guess}”. You’ve got ${gameData.livesRemaining} chances remaining!`);
+        return this.updateGameForGuild(guildId, gameData).then(() => ({
+          content: `Nope, there’s no “${guess}”. You’ve got ${gameData.livesRemaining} chances remaining!`,
+          embeds: [generateGameEmbed(gameData, false)]
+        }));
       }
 
       gameData.currentStreak = 0;


### PR DESCRIPTION
The Hangman Game plugin behaviour currently shows an embed with the updated game status on a correct guess, but only shows text on an incorrect guess. This change makes incorrect guesses also show the game status embed alongside the text.