### PR TITLE
Add image thumbnail to show Hangman Game state 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# Release 0.4.3 - Better Hangman Game state visualisation
+
+Adds a basic visualisation of the game state to the Hangman Game.
+
 # Release 0.4.2 - Better end-game Hangman Game response
 
 Updates the message that appears when the game is won or lost to show the full

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iris-bot",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iris-bot",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@vscode/sqlite3": "^5.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-bot",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Discord chatbot",
   "engines": {
     "npm": ">=7.0.0",

--- a/src/personality/constants/hangman-game.ts
+++ b/src/personality/constants/hangman-game.ts
@@ -7,3 +7,5 @@ export const summaryCommand = 'SHOW';
 export const dictionaryCommand = 'DICTIONARY';
 export const blankDisplayChar = '-';
 export const sqlCollection = 'hangman';
+export const graphicsRootUrl = 'https://jbrowne.io/iris-bot/resources/hmg-beta/';
+export const graphicsExtension = '.png';

--- a/src/personality/constants/hangman-game.ts
+++ b/src/personality/constants/hangman-game.ts
@@ -1,5 +1,7 @@
+import { COMMAND_PREFIX } from '../../constants/personality-constants';
+
 export const apiUrl = 'https://jbrowne.io/api/words/';
-export const prefix = '+HM';
+export const prefix = `${COMMAND_PREFIX}HM`;
 export const startCommand = 'START';
 export const guessCommand = 'GUESS';
 export const statsCommand = 'STATS';

--- a/src/personality/embeds/hangman-game.spec.ts
+++ b/src/personality/embeds/hangman-game.spec.ts
@@ -1,6 +1,6 @@
-import { MessageButton } from 'discord.js';
+import { MessageButton, MessageEmbed } from 'discord.js';
 
-import { dictionaryCommand, guessCommand, prefix, startCommand, statsCommand } from '../constants/hangman-game';
+import { dictionaryCommand, graphicsExtension, graphicsRootUrl, guessCommand, prefix, startCommand, statsCommand } from '../constants/hangman-game';
 import { DictionaryInfo, GameData } from '../interfaces/hangman-game';
 import {
   embedColorError,
@@ -87,6 +87,12 @@ describe('Hangman Game Status embed', () => {
     const gameData: GameData = mockNew;
     const guessSummary = generateGameEmbed(gameData).fields[0];
     expect(guessSummary.value).toContain('Words: *none*');
+  });
+
+  it('should have thumbnail image', () => {
+    const gameData: GameData = mockGame;
+    const embed = generateGameEmbed(gameData);
+    expect(embed.thumbnail.url).toBe(`${graphicsRootUrl}${mockGame.livesRemaining}${graphicsExtension}`);
   });
 });
 
@@ -254,6 +260,17 @@ describe('Hangman Game Won/Lost state message', () => {
       expect(button.label).toBe('Word definition');
       expect(button.url).toContain(winGameData.currentWord.toLowerCase());
     });
+
+    it('should have correct embed colour', () => {
+      const message = generateGameEndMesage(winGameData);
+      expect((message.embeds[0] as MessageEmbed).hexColor).toBe(embedColorNormal);
+    });
+
+    it('should have thumbnail image', () => {
+      const gameData: GameData = mockGame;
+      const embed = generateGameEmbed(gameData);
+      expect(embed.thumbnail.url).toBe(`${graphicsRootUrl}${mockGame.livesRemaining}${graphicsExtension}`);
+    });
   });
 
   describe('lost state', () => {
@@ -305,6 +322,17 @@ describe('Hangman Game Won/Lost state message', () => {
       expect(button.style).toBe('LINK');
       expect(button.label).toBe('Word definition');
       expect(button.url).toContain(loseGameData.currentWord.toLowerCase());
+    });
+
+    it('should have correct embed colour', () => {
+      const message = generateGameEndMesage(loseGameData);
+      expect((message.embeds[0] as MessageEmbed).hexColor).toBe(embedColorError);
+    });
+
+    it('should have thumbnail image', () => {
+      const gameData: GameData = mockGame;
+      const embed = generateGameEmbed(gameData);
+      expect(embed.thumbnail.url).toBe(`${graphicsRootUrl}${mockGame.livesRemaining}${graphicsExtension}`);
     });
   });
 });

--- a/src/personality/embeds/hangman-game.ts
+++ b/src/personality/embeds/hangman-game.ts
@@ -1,7 +1,16 @@
 import { MessageActionRow, MessageButton, MessageEmbed, MessageOptions } from 'discord.js';
 import { MessageButtonStyles } from 'discord.js/typings/enums';
 
-import { dictionaryCommand, guessCommand, prefix, startCommand, statsCommand, summaryCommand } from '../constants/hangman-game';
+import {
+  dictionaryCommand,
+  graphicsExtension,
+  graphicsRootUrl,
+  guessCommand,
+  prefix,
+  startCommand,
+  statsCommand,
+  summaryCommand
+} from '../constants/hangman-game';
 import { DictionaryInfo, GameData } from '../interfaces/hangman-game';
 import { convertMsecToHumanReadable } from '../utilities/hangman-game';
 
@@ -34,10 +43,10 @@ export function generateGameEmbed(gameData: GameData, useDefaultColor?: boolean)
   const countDisplay = `(${gameData.currentDisplay.length} letters)`;
   const chanceDisplay = `${gameData.livesRemaining} chances left`;
   embed.setDescription(`${letterDisplay} ${countDisplay}\n${chanceDisplay}`);
+  embed.setThumbnail(`${graphicsRootUrl}${gameData.livesRemaining}${graphicsExtension}`);
+
   const lettersSummary = gameData.wrongLetters.length > 0 ? gameData.wrongLetters.join() : '*none*';
-
   const wordsSummary = gameData.wrongWords.length > 0 ? gameData.wrongWords.join() : '*none*';
-
   embed.addField('Wrong guesses', `Letters: ${lettersSummary}\nWords: ${wordsSummary}`);
 
   return embed;
@@ -72,6 +81,7 @@ export function generateGameEndMesage(gameData: GameData): MessageOptions {
 
   const summaryEmbed = generateBaseEmbed(!isLoss);
   summaryEmbed.setDescription(gameData.currentWord);
+  summaryEmbed.setThumbnail(`${graphicsRootUrl}${gameData.livesRemaining}${graphicsExtension}`);
 
   const timeTaken = Date.now() - gameData.timeStarted;
 


### PR DESCRIPTION
Adds a small image representing the game's state to the embed thumbnail. The image is pulled from the API server and will be updated there based on feedback.

Addresses #85