### PR TITLE
Refactor plugins to use a customisable command prefix

### DIFF
--- a/src/engine/bot-engine.spec.ts
+++ b/src/engine/bot-engine.spec.ts
@@ -7,7 +7,7 @@ import { Personality } from '../interfaces/personality';
 import { ResponseGenerator } from '../interfaces/response-generator';
 import { Settings } from '../interfaces/settings';
 import { MessageType } from '../types';
-import { BotEngine, helpCommands } from './bot-engine';
+import { BotEngine, helpCommands, helpResponseText } from './bot-engine';
 import { HandledResponseError } from './handled-response-error';
 
 const MOCK_USERNAME = 'bot';
@@ -322,7 +322,7 @@ describe('Bot engine', () => {
 
         // Summary text
         expect(typeof messageQueue[0]).toBe('string');
-        expect(messageQueue[0]).toContain(helpCommand);
+        expect(messageQueue[0]).toBe(helpResponseText);
 
         // Embed
         const embed = messageQueue[1] as MessageEmbed;
@@ -340,7 +340,7 @@ describe('Bot engine', () => {
 
         // Summary text
         expect(typeof messageQueue[0]).toBe('string');
-        expect(messageQueue[0]).toContain(helpCommand);
+        expect(messageQueue[0]).toBe(helpResponseText);
 
         // Embed
         const embed = messageQueue[1] as MessageEmbed;

--- a/src/engine/bot-engine.ts
+++ b/src/engine/bot-engine.ts
@@ -1,6 +1,7 @@
 import { Message, MessageEmbed, User } from 'discord.js';
 
 import * as LifecycleEvents from '../constants/lifecycle-events';
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { Client } from '../interfaces/client';
 import { Engine } from '../interfaces/engine';
 import { Logger } from '../interfaces/logger';
@@ -11,7 +12,8 @@ import { MessageType } from '../types';
 import { getValueStartedWith, isPunctuation } from '../utils';
 import { HandledResponseError } from './handled-response-error';
 
-export const helpCommands = ['help', '+help'];
+export const helpCommands = ['help', COMMAND_PREFIX + 'help'];
+export const helpResponseText = `Hi, I’m {£me}. To get help with something, simply @ me with \`${helpCommands[0]}\` and then a topic from the list below.`;
 
 export class BotEngine implements Engine {
   private personalityConstructs: Personality[];
@@ -216,12 +218,11 @@ export class BotEngine implements Engine {
 
     const coreNames = coresWithHelp.map(core => `${core.constructor.name}`);
 
-    const responseText = `Hi, I’m {£me}. To get help with something, simply @ me with \`+help\` and then a topic from the list below.`;
     const messageEmbed = new MessageEmbed();
     const topics = coreNames.length ? '`' + coreNames.join('`\n`') + '`' : 'No topics';
     messageEmbed.addField('Help topics', topics);
 
-    this.client.queueMessages([responseText, messageEmbed]);
+    this.client.queueMessages([helpResponseText, messageEmbed]);
   }
 
   /**

--- a/src/personality/animal-images.spec.ts
+++ b/src/personality/animal-images.spec.ts
@@ -3,6 +3,7 @@ import { Message, MessageEmbed } from 'discord.js';
 import { StatusCodes } from 'http-status-codes';
 import { IMock, It, Mock } from 'typemoq';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Logger } from '../interfaces/logger';
 import { ResponseGenerator } from '../interfaces/response-generator';
@@ -48,8 +49,8 @@ describe('Animal Image API', () => {
     });
 
     supportedApis.forEach(apiName => {
-      it(`should call ${apiName.url} api when +${apiName.name} invoked`, done => {
-        const messageText = `+${apiName.name}`;
+      it(`should call ${apiName.url} api when ${COMMAND_PREFIX}${apiName.name} invoked`, done => {
+        const messageText = COMMAND_PREFIX + apiName.name;
         const mockSuccessResponse = {
           data: { link: apiName.url },
           status: StatusCodes.OK
@@ -68,7 +69,7 @@ describe('Animal Image API', () => {
       });
 
       it(`should handle API error for ${apiName.name}`, done => {
-        const messageText = `+${apiName.name}`;
+        const messageText = COMMAND_PREFIX + apiName.name;
         fetchSpy.and.returnValue(Promise.resolve({ status: StatusCodes.NOT_FOUND }));
 
         const message = Mock.ofType<Message>();
@@ -82,7 +83,7 @@ describe('Animal Image API', () => {
       });
 
       it(`should handle parsing error for ${apiName.name}`, done => {
-        const messageText = `+${apiName.name}`;
+        const messageText = COMMAND_PREFIX + apiName.name;
         fetchSpy.and.returnValue(Promise.reject());
 
         const message = Mock.ofType<Message>();
@@ -105,7 +106,7 @@ describe('Animal Image API', () => {
 
         const commandField = embed.fields[0];
         supportedApis.forEach(api => {
-          expect(commandField.value).toContain(`+${api.name}`);
+          expect(commandField.value).toContain(COMMAND_PREFIX + api.name);
         });
 
         done();

--- a/src/personality/animal-images.ts
+++ b/src/personality/animal-images.ts
@@ -2,6 +2,7 @@ import * as axios from 'axios';
 import { Message, MessageEmbed } from 'discord.js';
 import { StatusCodes } from 'http-status-codes';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
@@ -33,7 +34,7 @@ export class AnimalImages implements Personality {
   }
 
   onMessage(message: Message): Promise<MessageType> {
-    if (!message.content.startsWith('+')) {
+    if (!message.content.startsWith(COMMAND_PREFIX)) {
       return Promise.resolve(null);
     }
 
@@ -64,7 +65,7 @@ export class AnimalImages implements Personality {
     embed.setTitle('Animal Images');
     embed.setDescription(helpText);
 
-    const commands = supportedApis.map(api => `\`+${api.name}\``);
+    const commands = supportedApis.map(api => `\`${COMMAND_PREFIX}${api.name}\``);
     embed.addField('Commands', commands.join('\n'));
 
     return Promise.resolve(embed);

--- a/src/personality/basic-intelligence.spec.ts
+++ b/src/personality/basic-intelligence.spec.ts
@@ -1,15 +1,16 @@
 import { Message } from 'discord.js';
 import { Mock } from 'typemoq';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { BasicIntelligence } from './basic-intelligence';
 
 describe('basic intelligence', () => {
   it('should not handle an addressed message', (done: DoneFn) => {
     const message = Mock.ofType<Message>();
-    message.setup((m) => m.content).returns(() => 'anything');
+    message.setup(m => m.content).returns(() => 'anything');
     const core = new BasicIntelligence();
 
-    core.onAddressed(message.object, 'anything').then((result) => {
+    core.onAddressed(message.object, 'anything').then(result => {
       expect(result).toBe(null);
       done();
     });
@@ -17,10 +18,10 @@ describe('basic intelligence', () => {
 
   it('should handle an ambient message with the echo command', (done: DoneFn) => {
     const message = Mock.ofType<Message>();
-    message.setup((m) => m.content).returns(() => '+echo');
+    message.setup(m => m.content).returns(() => COMMAND_PREFIX + 'echo');
     const core = new BasicIntelligence();
 
-    core.onMessage(message.object).then((result) => {
+    core.onMessage(message.object).then(result => {
       expect(result).toBe('Echo!');
       done();
     });

--- a/src/personality/basic-intelligence.ts
+++ b/src/personality/basic-intelligence.ts
@@ -1,5 +1,6 @@
 import { Message } from 'discord.js';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
 
@@ -16,10 +17,7 @@ export class BasicIntelligence implements Personality {
    * @param message the message object related to this call
    * @param addressedMessage the substring of the message text after the attention grabber
    */
-  public onAddressed(
-    message: Message,
-    addressedMessage: string
-  ): Promise<MessageType> {
+  public onAddressed(message: Message, addressedMessage: string): Promise<MessageType> {
     return Promise.resolve(null);
   }
 
@@ -29,8 +27,8 @@ export class BasicIntelligence implements Personality {
    * @param message the message object related to this call
    */
   public onMessage(message: Message): Promise<MessageType> {
-    return new Promise((resolve) => {
-      if (message.content === '+echo') {
+    return new Promise(resolve => {
+      if (message.content === COMMAND_PREFIX + 'echo') {
         resolve('Echo!');
       }
 

--- a/src/personality/blog-roll.spec.ts
+++ b/src/personality/blog-roll.spec.ts
@@ -3,8 +3,9 @@ import { Message, MessageOptions, TextChannel } from 'discord.js';
 import { readFileSync, unlink } from 'fs';
 import { StatusCodes } from 'http-status-codes';
 import { IMock, It, Mock, Times } from 'typemoq';
-import { PostData, PostWrapper } from '../interfaces/blog-roll';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
+import { PostData, PostWrapper } from '../interfaces/blog-roll';
 import { Client } from '../interfaces/client';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Logger } from '../interfaces/logger';
@@ -141,7 +142,7 @@ describe('Blog roll', () => {
       channel.setup(c => c.id).returns(() => channelId);
 
       const message = Mock.ofType<Message>();
-      message.setup(m => m.content).returns(() => '+set channel');
+      message.setup(m => m.content).returns(() => COMMAND_PREFIX + 'set channel');
       message.setup(m => m.channel).returns(() => channel.object);
 
       const saveSpy = spyOn(personality as any, 'saveSettings');
@@ -160,7 +161,7 @@ describe('Blog roll', () => {
       channel.setup(c => c.id).returns(() => channelId);
 
       const message = Mock.ofType<Message>();
-      message.setup(m => m.content).returns(() => '+set channel');
+      message.setup(m => m.content).returns(() => COMMAND_PREFIX + 'set channel');
       message.setup(m => m.channel).returns(() => channel.object);
 
       personality.onMessage(message.object);

--- a/src/personality/blog-roll.ts
+++ b/src/personality/blog-roll.ts
@@ -3,6 +3,7 @@ import { Message, MessageEmbed, MessageOptions, TextChannel } from 'discord.js';
 import { readFile, writeFile } from 'fs';
 import { StatusCodes } from 'http-status-codes';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { PostData, PostWrapper } from '../interfaces/blog-roll';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
@@ -41,7 +42,7 @@ export class BlogRoll implements Personality {
   }
 
   public onMessage(message: Message): Promise<string> {
-    if (message.content === '+set channel') {
+    if (message.content === COMMAND_PREFIX + 'set channel') {
       const textChannel = message.channel as TextChannel;
       this.channelId = textChannel.id;
       this.saveSettings();

--- a/src/personality/constants/mc-server.ts
+++ b/src/personality/constants/mc-server.ts
@@ -1,7 +1,9 @@
+import { COMMAND_PREFIX } from '../../constants/personality-constants';
+
 // Commands
-export const statusCommand = '+MCSTATUS';
-export const setCommand = '+MCSET';
-export const announceCommand = '+MCANNOUNCE';
+export const statusCommand = COMMAND_PREFIX + 'MCSTATUS';
+export const setCommand = COMMAND_PREFIX + 'MCSET';
+export const announceCommand = COMMAND_PREFIX + 'MCANNOUNCE';
 
 // Responses
 export const noAssociationCopy = 'No Minecraft server associated with this Discord';

--- a/src/personality/stickers.ts
+++ b/src/personality/stickers.ts
@@ -2,6 +2,7 @@ import * as axios from 'axios';
 import { Message, MessageEmbed } from 'discord.js';
 import { StatusCodes } from 'http-status-codes';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
@@ -9,7 +10,7 @@ import { MessageType } from '../types';
 const stickerReferenceUrl = 'https://jbrowne.io/iris-bot/stickers/';
 const apiUrl = 'https://jbrowne.io/api/stickers/index.php';
 
-export const prefix = '+s ';
+export const prefix = COMMAND_PREFIX + 's ';
 export const helpText = `Posts a large sticker image to chat. All image names can be found at ${stickerReferenceUrl}`;
 
 export interface Sticker {

--- a/src/personality/tally-personality.ts
+++ b/src/personality/tally-personality.ts
@@ -1,14 +1,15 @@
 import { Message } from 'discord.js';
 
+import { COMMAND_PREFIX } from '../constants/personality-constants';
 import { QueryFilter } from '../interfaces/database';
 import { DependencyContainer } from '../interfaces/dependency-container';
 import { Personality } from '../interfaces/personality';
 import { MessageType } from '../types';
 
 export const collection = 'tally';
-export const addCommand = '+add';
-export const totalCountCommand = '+total';
-export const resetCountCommand = '+reset';
+export const addCommand = COMMAND_PREFIX + 'add';
+export const totalCountCommand = COMMAND_PREFIX + 'total';
+export const resetCountCommand = COMMAND_PREFIX + 'reset';
 
 interface GuildCount {
   guildId: string;
@@ -17,9 +18,7 @@ interface GuildCount {
 
 function generateWhere(guildId: string): QueryFilter {
   return {
-    where: [
-      { field: 'guildId', value: guildId }
-    ]
+    where: [{ field: 'guildId', value: guildId }]
   };
 }
 
@@ -51,33 +50,29 @@ export class TallyPersonality implements Personality {
   private addToCounter(guildId: string): Promise<string> {
     return this.dependencies.database
       .getRecordsFromCollection<GuildCount>(collection, generateWhere(guildId))
-      .then((results) => {
+      .then(results => {
         if (results.length === 0) {
           const insertObject: GuildCount = {
             guildId: guildId,
             count: 1
           };
 
-          return this.dependencies.database
-            .insertRecordsToCollection(collection, { ...insertObject })
-            .then(() => {
-              this.dependencies.logger.log('Added successfully');
-              return 'The tally is 1';
-            });
+          return this.dependencies.database.insertRecordsToCollection(collection, { ...insertObject }).then(() => {
+            this.dependencies.logger.log('Added successfully');
+            return 'The tally is 1';
+          });
         }
 
         const updatedCount = results[0].count + 1;
         const fieldInfo = { $count: updatedCount };
         const filter = { $guildId: guildId };
 
-        return this.dependencies.database
-          .updateRecordsInCollection(collection, fieldInfo, filter)
-          .then(() => {
-            this.dependencies.logger.log('Updated successfully');
-            return `The tally is ${updatedCount}`;
-          });
+        return this.dependencies.database.updateRecordsInCollection(collection, fieldInfo, filter).then(() => {
+          this.dependencies.logger.log('Updated successfully');
+          return `The tally is ${updatedCount}`;
+        });
       })
-      .catch((err) => {
+      .catch(err => {
         console.error(err);
         return 'Not right now';
       });
@@ -86,7 +81,7 @@ export class TallyPersonality implements Personality {
   private resetCounter(guildId: string): Promise<string> {
     return this.dependencies.database
       .getRecordsFromCollection<GuildCount>(collection, generateWhere(guildId))
-      .then((results) => {
+      .then(results => {
         if (results.length === 0) {
           return 'The counter has never been used'; // Tally is zero for all unkown guilds
         }
@@ -94,13 +89,12 @@ export class TallyPersonality implements Personality {
         const fieldInfo = { $count: 0 };
         const filter = { $guildId: guildId };
 
-        return this.dependencies.database
-          .updateRecordsInCollection(collection, fieldInfo, filter)
-          .then(() => {
-            this.dependencies.logger.log('Reset successfully');
-            return 'Gotcha';
-          });
-      }).catch((err) => {
+        return this.dependencies.database.updateRecordsInCollection(collection, fieldInfo, filter).then(() => {
+          this.dependencies.logger.log('Reset successfully');
+          return 'Gotcha';
+        });
+      })
+      .catch(err => {
         console.error(err);
         return 'Can’t do that right now';
       });
@@ -109,7 +103,7 @@ export class TallyPersonality implements Personality {
   private getCounter(guildId: string): Promise<string> {
     return this.dependencies.database
       .getRecordsFromCollection<GuildCount>(collection, generateWhere(guildId))
-      .then((results) => {
+      .then(results => {
         if (results.length === 0) {
           return 'Zero';
         }
@@ -117,7 +111,7 @@ export class TallyPersonality implements Personality {
         const row = results[0];
         return `The tally is ${row.count}`;
       })
-      .catch((err) => {
+      .catch(err => {
         this.dependencies.logger.error(err);
         return 'Zero';
       });


### PR DESCRIPTION
In most of the bot plugins use a hard-coded command prefix of `+`. The bot constants file has a variable for command prefix which was used in some places but not in others.

This change set makes the remaining hard-coded places use the variable so that the command prefixes for plugins are consistent.