### PR TITLE
Actually fix double plural in Hangman Game plugin status embed

### DIFF
--- a/src/personality/embeds/hangman-game.spec.ts
+++ b/src/personality/embeds/hangman-game.spec.ts
@@ -94,6 +94,22 @@ describe('Hangman Game Status embed', () => {
     const embed = generateGameEmbed(gameData);
     expect(embed.thumbnail.url).toBe(`${graphicsRootUrl}${mockGame.livesRemaining}${graphicsExtension}`);
   });
+
+  it('should pluralise the word chances correctly', () => {
+    const clonedGameData = { ...mockGame };
+
+    clonedGameData.livesRemaining = 0;
+    let embed = generateGameEmbed(clonedGameData);
+    expect(embed.description).toContain('0 chances');
+
+    clonedGameData.livesRemaining = 1;
+    embed = generateGameEmbed(clonedGameData);
+    expect(embed.description).toContain('1 chance');
+
+    clonedGameData.livesRemaining = 2;
+    embed = generateGameEmbed(clonedGameData);
+    expect(embed.description).toContain('2 chances');
+  });
 });
 
 describe('Hangman Game Help embed', () => {

--- a/src/personality/embeds/hangman-game.ts
+++ b/src/personality/embeds/hangman-game.ts
@@ -41,7 +41,7 @@ export function generateGameEmbed(gameData: GameData, useDefaultColor?: boolean)
   const embed = generateBaseEmbed(useDefaultColor);
   const letterDisplay = `\`${gameData.currentDisplay}\``;
   const countDisplay = `(${gameData.currentDisplay.length} letters)`;
-  const chanceDisplay = `${gameData.livesRemaining} ${pluraliseWord('chances', gameData.livesRemaining)} left`;
+  const chanceDisplay = `${gameData.livesRemaining} ${pluraliseWord('chance', gameData.livesRemaining)} left`;
   embed.setDescription(`${letterDisplay} ${countDisplay}\n${chanceDisplay}`);
   embed.setThumbnail(`${graphicsRootUrl}${gameData.livesRemaining}${graphicsExtension}`);
 


### PR DESCRIPTION
Fix the double plural typo in the Hangman Game plugin status embed. Also added tests to check this because they were missing.