### PR TITLE
Fix bad message handling

### DIFF
--- a/src/interfaces/client.ts
+++ b/src/interfaces/client.ts
@@ -1,4 +1,4 @@
-import { TextBasedChannel, PresenceData, User } from 'discord.js';
+import { Message, PresenceData, TextBasedChannel, User } from 'discord.js';
 import { EventEmitter } from 'events';
 
 import { MessageType } from '../types';
@@ -40,7 +40,7 @@ export interface Client extends EventEmitter {
    *
    * @param messages messages to queue
    */
-  queueMessages(messages: MessageType[]): void;
+  queueMessages(source: Message, messages: MessageType[]): void;
 
   /**
    * Sets the client's presence and activity data

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": ["**/*.spec.ts", "**/*.specdata.ts", "spec/**"]
+  "exclude": ["**/*.spec.ts", "**/*.specdata.ts", "jest.config.ts"]
 }


### PR DESCRIPTION
This change set removes the caching of the last received message from the bot's discord client. The old behaviour meant if a message comes in during processing, it would potentially respond to the wrong channel.

The code has been updated to explicitly pass through the source message so the response is sent to the same channel 

Addresses #49 