### PR TITLE
Remove deprecated minecraft-server-utils package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "bufferutil": "^4.0.7",
         "discord.js": "^13.15.0",
         "http-status-codes": "^2.2.0",
-        "minecraft-server-util": "^5.4.2",
         "node-cleanup": "^2.1.2",
         "sqlite3": "^5.1.6",
         "utf-8-validate": "^6.0.3"
@@ -5325,22 +5324,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/minecraft-motd-util": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/minecraft-motd-util/-/minecraft-motd-util-1.1.12.tgz",
-      "integrity": "sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA=="
-    },
-    "node_modules/minecraft-server-util": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/minecraft-server-util/-/minecraft-server-util-5.4.2.tgz",
-      "integrity": "sha512-QjCM23pnXya+Fi2i3VxpQ5RS6luBA6Tkr0GAIG9dVhOrG5fBw10MVQyd13fJ4RquY3jQwNiHGX05G/0lnrQD5A==",
-      "dependencies": {
-        "minecraft-motd-util": "^1.1.9"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -11151,19 +11134,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "minecraft-motd-util": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/minecraft-motd-util/-/minecraft-motd-util-1.1.12.tgz",
-      "integrity": "sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA=="
-    },
-    "minecraft-server-util": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/minecraft-server-util/-/minecraft-server-util-5.4.2.tgz",
-      "integrity": "sha512-QjCM23pnXya+Fi2i3VxpQ5RS6luBA6Tkr0GAIG9dVhOrG5fBw10MVQyd13fJ4RquY3jQwNiHGX05G/0lnrQD5A==",
-      "requires": {
-        "minecraft-motd-util": "^1.1.9"
-      }
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "bufferutil": "^4.0.7",
     "discord.js": "^13.15.0",
     "http-status-codes": "^2.2.0",
-    "minecraft-server-util": "^5.4.2",
     "node-cleanup": "^2.1.2",
     "sqlite3": "^5.1.6",
     "utf-8-validate": "^6.0.3"

--- a/src/personality/embeds/mc-server.spec.ts
+++ b/src/personality/embeds/mc-server.spec.ts
@@ -10,17 +10,31 @@ describe('Embed formatting for Minecraft server utilities', () => {
     const serverVersion = '1.2.3';
 
     const onlineWithPlayers: ServerResponse = {
-      version: serverVersion,
-      onlinePlayers: 2,
-      maxPlayers: 4,
-      samplePlayers: [{ name: 'a' }, { name: 'b' }]
+      online: true,
+      host: 'online-server',
+      port: 25565,
+      version: {
+        name_clean: '1.2.3'
+      },
+      players: {
+        online: 2,
+        max: 5,
+        list: [{ name_clean: 'user' }, { name_clean: 'user2' }]
+      }
     };
 
     const onlineNoPlayers: ServerResponse = {
-      version: serverVersion,
-      onlinePlayers: 0,
-      maxPlayers: 4,
-      samplePlayers: []
+      online: true,
+      host: 'online-server',
+      port: 25565,
+      version: {
+        name_clean: '1.2.3'
+      },
+      players: {
+        online: 0,
+        max: 5,
+        list: []
+      }
     };
 
     const onlinePlayersEmbed = embeds.generateServerEmbed(serverUrl, onlineWithPlayers);
@@ -61,9 +75,9 @@ describe('Embed formatting for Minecraft server utilities', () => {
       expect(onlinePlayersEmbed.fields.length).toBeGreaterThan(0);
 
       const onlineServerPlayersField = onlinePlayersEmbed.fields.find(f => f.name.startsWith(embeds.fieldTitlePlayers));
-      expect(onlineServerPlayersField?.name).toBe(`${embeds.fieldTitlePlayers} (${onlineWithPlayers.onlinePlayers})`);
-      onlineWithPlayers.samplePlayers.forEach(player => {
-        expect(onlineServerPlayersField?.value).toContain(player.name);
+      expect(onlineServerPlayersField?.name).toBe(`${embeds.fieldTitlePlayers} (${onlineWithPlayers.players?.online})`);
+      onlineWithPlayers.players?.list.forEach(player => {
+        expect(onlineServerPlayersField?.value).toContain(player.name_clean);
       });
 
       const offlineServerPlayersField = onlineEmptyEmbed.fields.find(f => f.name.startsWith(embeds.fieldTitlePlayers));

--- a/src/personality/embeds/mc-server.ts
+++ b/src/personality/embeds/mc-server.ts
@@ -1,4 +1,4 @@
-import { EmbedFieldData, MessageEmbed } from 'discord.js';
+import { MessageEmbed } from 'discord.js';
 
 import { announceCommand, defaultDescription, noAssociationCopy, setCommand, statusCommand } from '../constants/mc-server';
 import { ServerResponse } from '../interfaces/mc-server';
@@ -41,8 +41,8 @@ export function generateHelpEmbed(): MessageEmbed {
  * @returns a MessageEmbed containing a summary of the server status
  */
 export function generateServerEmbed(url: string, status: ServerResponse | null): MessageEmbed {
-  const isOnline = status !== null;
-  const description = status && status.description ? status.description : defaultDescription;
+  const isOnline = status !== null && status.online;
+  const description = status?.motd?.clean || defaultDescription;
   const statusText = isOnline ? 'online' : 'offline';
 
   const embed = new MessageEmbed();
@@ -51,15 +51,15 @@ export function generateServerEmbed(url: string, status: ServerResponse | null):
   embed.setColor(isOnline ? embedSuccessColor : embedErrorColor);
 
   // Version field
-  if (status && status.version) {
-    const fieldData = { name: fieldTitleVersion, value: status.version };
+  if (status && status.version && status.version.name_clean) {
+    const fieldData = { name: fieldTitleVersion, value: status.version.name_clean };
     embed.addFields([fieldData]);
   }
 
-  if (isOnline && status.onlinePlayers && status.onlinePlayers > 0) {
+  if (isOnline && status.players && status.players.online > 0) {
     // Sample players is occasionally not populated
-    const players = (status.samplePlayers || []).map(p => p.name);
-    const fieldData = { name: `${fieldTitlePlayers} (${status.onlinePlayers})`, value: players.join('\n') };
+    const players = (status.players.list || []).map(p => p.name_clean);
+    const fieldData = { name: `${fieldTitlePlayers} (${status.players.online})`, value: players.join('\n') };
     embed.addFields([fieldData]);
   }
 

--- a/src/personality/interfaces/mc-server.ts
+++ b/src/personality/interfaces/mc-server.ts
@@ -4,14 +4,30 @@ export interface ServerInformation {
   lastKnownOnline: boolean;
 }
 
+export interface ServerVersion {
+  name_clean: string;
+}
+
 export interface ServerPlayer {
-  name: string;
+  name_clean: string;
+}
+
+export interface ServerPlayers {
+  online: number;
+  max: number;
+  list: ServerPlayer[];
+}
+
+export interface ServerMotd {
+  clean: string;
 }
 
 export interface ServerResponse {
-  version: string;
-  onlinePlayers: number;
-  maxPlayers: number;
-  samplePlayers: ServerPlayer[];
-  description?: string;
+  online: boolean;
+  host: string;
+  port: number;
+  version?: ServerVersion;
+  players?: ServerPlayers;
+  motd?: ServerMotd;
+  icon?: string;
 }


### PR DESCRIPTION
This changeset changes the Minecraft server status plugin so that it uses the public API provided by mcstatus.io. This means it no longer has a dependency on the `minecraft-server-utils` package which has a deprecation warning.

Moving to the public API also allows the Minecraft server plugin to behave more akin to the other internet connected plugins in the sense it uses HTTP requests. This should make it more stable.